### PR TITLE
doc(leases/lease.go): add godoc for TimeFormat

### DIFF
--- a/leases/lease.go
+++ b/leases/lease.go
@@ -6,6 +6,8 @@ import (
 )
 
 const (
+	// TimeFormat is the standard format that all lease expiration times are stored as in k8s
+	// annotations
 	TimeFormat = time.RFC3339
 )
 


### PR DESCRIPTION
This helps our go report card results
