### PR TITLE
fix(leases): modify the annotation parser to ignore invalid leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ This response code is returned if any of the following occur:
 
 - The server couldn't communicate with the Kubernetes Master to get the service object
 - The server couldn't communicate with the GKE API
-- The annotations on the service object were malformed
 - A cluster was available, but the new lease information couldn't be saved
 - An expired lease exists but it points to a non-existent cluster
 - The lease was succesful but the response body couldn't be rendered
@@ -108,7 +107,6 @@ This response code is returned in the following cases:
 This response code is returned in the following cases:
 
 - The server couldn't communicate with the Kubernetes Master to get the service object
-- The annotations on the service object were malformed
 - The lease was found and deleted, but the updated lease statuses couldn't be saved
 
 #### `409 Conflict`

--- a/handlers/delete_lease_test.go
+++ b/handlers/delete_lease_test.go
@@ -34,6 +34,8 @@ func TestDeleteLeaseInvalidLeaseToken(t *testing.T) {
 }
 
 func TestDeleteLeaseInvalidAnnotations(t *testing.T) {
+	// Issue a DELETE with a lease token that doesn't point to a valid lease.
+	// Annotations have invalid data in them, which the lease parser should just ignore.
 	getterUpdater := newFakeServiceGetterUpdater(
 		&api.Service{ObjectMeta: api.ObjectMeta{Annotations: map[string]string{"a": "b"}}},
 		nil,
@@ -45,7 +47,7 @@ func TestDeleteLeaseInvalidAnnotations(t *testing.T) {
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
-	assert.Equal(t, res.Code, http.StatusInternalServerError, "response code")
+	assert.Equal(t, res.Code, http.StatusConflict, "response code")
 }
 
 func TestDeleteLeaseNoSuchLease(t *testing.T) {

--- a/leases/errors.go
+++ b/leases/errors.go
@@ -15,18 +15,6 @@ func (m ErrMalformedUUID) Error() string {
 	return "malformed UUID: " + m.uuidStr
 }
 
-// ErrParseLease is an error implementation that's returned whenever a func failed to parse a
-// lease from json
-type ErrParseLease struct {
-	leaseStr string
-	parseErr error
-}
-
-// Error is the error interface implementation
-func (e ErrParseLease) Error() string {
-	return fmt.Sprintf("parsing lease %s (%s)", e.leaseStr, e.parseErr)
-}
-
 // ErrEncodeLease is an error implementation that's returned whenever a func failed to encode a
 // lease into json
 type ErrEncodeLease struct {

--- a/leases/map.go
+++ b/leases/map.go
@@ -21,13 +21,15 @@ func ParseMapFromAnnotations(annotations map[string]string) (*Map, error) {
 	uuidMap := make(map[string]*Lease)
 	nameMap := make(map[string]uuid.UUID)
 	for uuidStr, leaseStr := range annotations {
+		// try to parse the UUID and the lease, but skip if the annotation has a malformed UUID or
+		// lease. This is to work in clusters that have other annotations
 		u := uuid.Parse(uuidStr)
 		if u == nil {
-			return nil, ErrMalformedUUID{uuidStr: uuidStr}
+			continue
 		}
 		lease, err := ParseLease(leaseStr)
 		if err != nil {
-			return nil, ErrParseLease{leaseStr: leaseStr, parseErr: err}
+			continue
 		}
 		uuidMap[u.String()] = lease
 		nameMap[lease.ClusterName] = u


### PR DESCRIPTION
In most environments, this program will have to share the annotation namespace with annotations for other purposes. Specifically, this PR allows the claimer to run inside Deis environments.
