### PR TITLE
fix(handlers): refactor and write end-to-end tests for the create lease handler

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8e629128ef7d71e9c3b1e311f8e5ff46df47a58c30f4d080ba7047c65ae2558a
-updated: 2016-04-07T14:45:30.302452415-07:00
+hash: 2897899614ccf56f1a2559208be0ce2aa44454890add82b08006eeb2155a6ed1
+updated: 2016-04-13T10:56:56.724950967-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -138,10 +138,11 @@ imports:
 - name: gopkg.in/yaml.v2
   version: d466437aa4adc35830964cffc5b5f262c63ddcb4
 - name: k8s.io/kubernetes
-  version: 752a085d5703fce1f0b89e4241ffc8a848b42bef
+  version: 487e70173625fe7e33b28e7989735b496d86fe01
   subpackages:
   - pkg/client/unversioned
   - pkg/api
+  - pkg/client/unversioned/clientcmd/api
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,4 +8,3 @@ import:
 - package: k8s.io/kubernetes
   version: ~1.2
 - package: github.com/arschles/assert
-- package: gopkg.in/yaml.v2

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -83,7 +82,7 @@ func CreateLease(
 		}
 
 		newToken := uuid.NewUUID()
-		kubeConfigBytes, err := createKubeConfigFromCluster(availableCluster)
+		kubeConfig, err := createKubeConfigFromCluster(availableCluster)
 		if err != nil {
 			htp.Error(
 				w,
@@ -94,7 +93,12 @@ func CreateLease(
 			)
 			return
 		}
-		kubeConfigStr := base64.StdEncoding.EncodeToString(kubeConfigBytes)
+		kubeConfigStr, err := marshalAndEncodeKubeConfig(kubeConfig)
+		if err != nil {
+			htp.Error(w, http.StatusInternalServerError, "error marshaling & encoding kubeconfig (%s)", err)
+			return
+		}
+
 		resp := createLeaseResp{
 			KubeConfig:  kubeConfigStr,
 			IP:          availableCluster.Endpoint,

--- a/handlers/search_free_cluster.go
+++ b/handlers/search_free_cluster.go
@@ -22,6 +22,12 @@ func (e errExpiredLeaseGKEMissing) Error() string {
 	return fmt.Sprintf("cluster %s has an expired lease but does not exist in GKE", e.clusterName)
 }
 
+// searchForFreeCluster first looks in GKE first for a GKE cluster that has no lease associated
+// with it and returns it.
+//
+// Returns errNoAvailableOrExpiredClustersFound if it found no free or expired lease clusters.
+// Returns errExpiredLeaseGKEMissing if it found an expired lease but the cluster associated with
+// that lease doesn't exist in GKE
 func searchForFreeCluster(clusterMap *clusters.Map, leaseMap *leases.Map) (*container.Cluster, error) {
 	unusedCluster, unusedClusterErr := findUnusedGKECluster(clusterMap, leaseMap)
 	uuidAndLease, expiredLeaseErr := findExpiredLease(leaseMap)

--- a/handlers/search_free_cluster.go
+++ b/handlers/search_free_cluster.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/deis/k8s-claimer/clusters"
+	"github.com/deis/k8s-claimer/leases"
+	container "google.golang.org/api/container/v1"
+)
+
+type errNoAvailableOrExpiredClustersFound struct{}
+
+func (e errNoAvailableOrExpiredClustersFound) Error() string {
+	return "no available or expired clusters found"
+}
+
+type errExpiredLeaseGKEMissing struct {
+	clusterName string
+}
+
+func (e errExpiredLeaseGKEMissing) Error() string {
+	return fmt.Sprintf("cluster %s has an expired lease but does not exist in GKE", e.clusterName)
+}
+
+func searchForFreeCluster(clusterMap *clusters.Map, leaseMap *leases.Map) (*container.Cluster, error) {
+	unusedCluster, unusedClusterErr := findUnusedGKECluster(clusterMap, leaseMap)
+	uuidAndLease, expiredLeaseErr := findExpiredLease(leaseMap)
+	if unusedClusterErr != nil && expiredLeaseErr != nil {
+		return nil, errNoAvailableOrExpiredClustersFound{}
+	}
+	var availableCluster *container.Cluster
+	if unusedCluster != nil {
+		availableCluster = unusedCluster
+	}
+	if expiredLeaseErr == nil {
+		cl, ok := clusterMap.ClusterByName(uuidAndLease.Lease.ClusterName)
+		if !ok {
+			return nil, errExpiredLeaseGKEMissing{clusterName: uuidAndLease.Lease.ClusterName}
+		}
+		leaseMap.DeleteLease(uuidAndLease.UUID)
+		availableCluster = cl
+	}
+
+	return availableCluster, nil
+}

--- a/handlers/search_free_cluster_test.go
+++ b/handlers/search_free_cluster_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/deis/k8s-claimer/clusters"
+	"github.com/deis/k8s-claimer/gke"
+	"github.com/deis/k8s-claimer/leases"
+	"github.com/deis/k8s-claimer/testutil"
+	"github.com/pborman/uuid"
+	container "google.golang.org/api/container/v1"
+)
+
+// check for no clusters found
+func TestSearchForFreeClusterNoneAvailable(t *testing.T) {
+	leaseMap, err := leases.ParseMapFromAnnotations(map[string]string{})
+	assert.NoErr(t, err)
+	clusterLister := gke.FakeClusterLister{Err: nil, Resp: &container.ListClustersResponse{Clusters: nil}}
+	clusterMap, err := clusters.ParseMapFromGKE(clusterLister, "", "")
+	assert.NoErr(t, err)
+	cluster, err := searchForFreeCluster(clusterMap, leaseMap)
+	assert.Nil(t, cluster, "cluster")
+	switch tErr := err.(type) {
+	case errNoAvailableOrExpiredClustersFound:
+	default:
+		t.Fatalf("returned error was not a errNoAvailableOrExpiredClustersFound (it was a %s)", reflect.TypeOf(tErr))
+	}
+}
+
+// check for expired lease but found no clusters
+func TestSearchForClusterNoLeaseFound(t *testing.T) {
+	const clusterName = "cluster1"
+	leaseMap, err := leases.ParseMapFromAnnotations(map[string]string{
+		uuid.New(): testutil.LeaseJSON(clusterName, time.Now().Add(-1*time.Hour), leases.TimeFormat),
+	})
+	assert.NoErr(t, err)
+	clusterLister := gke.FakeClusterLister{
+		Err:  nil,
+		Resp: &container.ListClustersResponse{Clusters: nil},
+	}
+	clusterMap, err := clusters.ParseMapFromGKE(clusterLister, "", "")
+	assert.NoErr(t, err)
+	cluster, err := searchForFreeCluster(clusterMap, leaseMap)
+	assert.Nil(t, cluster, "cluster")
+	switch tErr := err.(type) {
+	case errExpiredLeaseGKEMissing:
+		assert.Equal(t, tErr.clusterName, clusterName, "cluster name")
+	default:
+		t.Fatalf("returned error was not a errExpiredLeaseGKEMissing (it was a %s)", reflect.TypeOf(tErr))
+	}
+}


### PR DESCRIPTION
Fixes #19 

The refactor is to make it easier to write tests for smaller portions of the handler.

This PR now brings the `handlers` package to 70.5% coverage:

``` console
ok      github.com/deis/k8s-claimer/handlers    0.019s  coverage: 70.5% of statements
```
