### PR TITLE
fix(config/google.go): default to using clusters from all zones

### DIFF
--- a/config/google.go
+++ b/config/google.go
@@ -11,7 +11,7 @@ import (
 type GoogleCloud struct {
 	AccountFileBase64 string `envconfig:"GOOGLE_CLOUD_ACCOUNT_FILE_BASE64" required:"true"`
 	ProjectID         string `envconfig:"GOOGLE_CLOUD_PROJECT_ID" required:"true"`
-	Zone              string `envconfig:"GOOGLE_CLOUD_ZONE" required:"true"`
+	Zone              string `envconfig:"GOOGLE_CLOUD_ZONE" default:"-"`
 }
 
 // GoogleCloudAccountFile represents the structure of the account file JSON file.


### PR DESCRIPTION
Fixes #37 

The docs at https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters/list say that you can use `-` to indicate all zones. Testing agrees
