### PR TITLE
fix(create_lease.go): add cluster name to the response of the create handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ acquired.
 {
   "kubeconfig": "RFC 4648 base64 encoded Kubernetes config file. After decoding, this value can be written to ~/.kube/config for use with kubectl",
   "ip": "The IP address of the Kubernetes master server in GKE",
-  "token": "The token of the lease. This is your proof of ownership of the cluster, until the lease expires or you release it"
+  "token": "The token of the lease. This is your proof of ownership of the cluster, until the lease expires or you release it",
+  "cluster_name": "The name of the cluster. This value is purely informational, and fetched from GKE"
 }
 ```
 

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -20,9 +20,10 @@ type createLeaseReq struct {
 }
 
 type createLeaseResp struct {
-	KubeConfig string `json:"kubeconfig"`
-	IP         string `json:"ip"`
-	Token      string `json:"uuid"`
+	KubeConfig  string `json:"kubeconfig"`
+	IP          string `json:"ip"`
+	Token       string `json:"uuid"`
+	ClusterName string `json:"cluster_name"`
 }
 
 func (c createLeaseReq) maxTimeDur() time.Duration {
@@ -95,9 +96,10 @@ func CreateLease(
 		}
 		kubeConfigStr := base64.StdEncoding.EncodeToString(kubeConfigBytes)
 		resp := createLeaseResp{
-			KubeConfig: kubeConfigStr,
-			IP:         availableCluster.Endpoint,
-			Token:      newToken.String(),
+			KubeConfig:  kubeConfigStr,
+			IP:          availableCluster.Endpoint,
+			Token:       newToken.String(),
+			ClusterName: availableCluster.Name,
 		}
 
 		leaseMap.CreateLease(newToken, leases.NewLease(availableCluster.Name, req.expirationTime(time.Now())))


### PR DESCRIPTION
It's useful for debugging to be able to see the cluster name. Also, if you name your test clusters with a theme, it's cool to see them.
