### PR TITLE
fix(main.go): allow path parameters on DELETE

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	services := k8sClient.Services(serverConf.Namespace)
 	mux := http.NewServeMux()
-	leaseHandler := htp.MethodMux(map[htp.Method]http.Handler{
+	createLeaseHandler := htp.MethodMux(map[htp.Method]http.Handler{
 		htp.Post: handlers.CreateLease(
 			gke.NewGKEClusterLister(containerService),
 			services,
@@ -51,9 +51,12 @@ func main() {
 			gCloudConf.ProjectID,
 			gCloudConf.Zone,
 		),
+	})
+	deleteLeaseHandler := htp.MethodMux(map[htp.Method]http.Handler{
 		htp.Delete: handlers.DeleteLease(services, serverConf.ServiceName),
 	})
-	mux.Handle("/lease", leaseHandler)
+	mux.Handle("/lease", createLeaseHandler)
+	mux.Handle("/lease/", deleteLeaseHandler)
 
 	log.Printf("Running %s on %s", appName, serverConf.HostStr())
 	http.ListenAndServe(serverConf.HostStr(), mux)

--- a/main.go
+++ b/main.go
@@ -15,6 +15,13 @@ const (
 	appName = "k8s-claimer"
 )
 
+func configureRoutes(serveMux *http.ServeMux, createLeaseHandler http.Handler, deleteLeaseHandler http.Handler) {
+	createLeaseHandler = htp.MethodMux(map[htp.Method]http.Handler{htp.Post: createLeaseHandler})
+	deleteLeaseHandler = htp.MethodMux(map[htp.Method]http.Handler{htp.Delete: deleteLeaseHandler})
+	serveMux.Handle("/lease", createLeaseHandler)
+	serveMux.Handle("/lease/", deleteLeaseHandler)
+}
+
 func main() {
 	serverConf, err := parseServerConfig(appName)
 	if err != nil {
@@ -43,20 +50,15 @@ func main() {
 
 	services := k8sClient.Services(serverConf.Namespace)
 	mux := http.NewServeMux()
-	createLeaseHandler := htp.MethodMux(map[htp.Method]http.Handler{
-		htp.Post: handlers.CreateLease(
-			gke.NewGKEClusterLister(containerService),
-			services,
-			serverConf.ServiceName,
-			gCloudConf.ProjectID,
-			gCloudConf.Zone,
-		),
-	})
-	deleteLeaseHandler := htp.MethodMux(map[htp.Method]http.Handler{
-		htp.Delete: handlers.DeleteLease(services, serverConf.ServiceName),
-	})
-	mux.Handle("/lease", createLeaseHandler)
-	mux.Handle("/lease/", deleteLeaseHandler)
+	createLeaseHandler := handlers.CreateLease(
+		gke.NewGKEClusterLister(containerService),
+		services,
+		serverConf.ServiceName,
+		gCloudConf.ProjectID,
+		gCloudConf.Zone,
+	)
+	deleteLeaseHandler := handlers.DeleteLease(services, serverConf.ServiceName)
+	configureRoutes(mux, createLeaseHandler, deleteLeaseHandler)
 
 	log.Printf("Running %s on %s", appName, serverConf.HostStr())
 	http.ListenAndServe(serverConf.HostStr(), mux)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arschles/assert"
+)
+
+type configureRoutesTestCase struct {
+	postHandler   http.Handler
+	deleteHandler http.Handler
+	method        string
+	path          string
+	respCode      int
+	respBody      string
+}
+
+func TestConfigureRoutes(t *testing.T) {
+	handler1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("handler1"))
+	})
+	handler2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusFound)
+		w.Write([]byte("handler2"))
+	})
+	testCases := []configureRoutesTestCase{
+		configureRoutesTestCase{
+			postHandler:   handler1,
+			deleteHandler: handler2,
+			method:        "GET",
+			path:          "/lease",
+			respCode:      http.StatusNotFound,
+			respBody:      "GET /lease not found",
+		},
+		configureRoutesTestCase{
+			postHandler:   handler1,
+			deleteHandler: handler2,
+			method:        "POST",
+			path:          "/lease",
+			respCode:      http.StatusOK,
+			respBody:      "handler1",
+		},
+		configureRoutesTestCase{
+			postHandler:   handler1,
+			deleteHandler: handler2,
+			method:        "POST",
+			path:          "/lease/abc",
+			respCode:      http.StatusNotFound,
+			respBody:      "POST /lease/abc not found",
+		},
+		configureRoutesTestCase{
+			postHandler:   handler1,
+			deleteHandler: handler2,
+			method:        "DELETE",
+			path:          "/lease",
+			respCode:      http.StatusNotFound,
+			respBody:      "DELETE /lease not found",
+		},
+		configureRoutesTestCase{
+			postHandler:   handler1,
+			deleteHandler: handler2,
+			method:        "DELETE",
+			path:          "/lease/abc",
+			respCode:      http.StatusFound,
+			respBody:      "handler2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		mux := http.NewServeMux()
+		configureRoutes(mux, testCase.postHandler, testCase.deleteHandler)
+		req, err := http.NewRequest(testCase.method, testCase.path, nil)
+		assert.NoErr(t, err)
+		res := httptest.NewRecorder()
+		mux.ServeHTTP(res, req)
+		assert.Equal(
+			t,
+			res.Code,
+			testCase.respCode,
+			fmt.Sprintf("response code for %s %s", testCase.method, testCase.path),
+		)
+		assert.Equal(
+			t,
+			strings.TrimSpace(string(res.Body.Bytes())),
+			testCase.respBody,
+			fmt.Sprintf("response body for %s %s", testCase.method, testCase.path),
+		)
+	}
+}


### PR DESCRIPTION
The handler for delete did not allow for path parameters. This PR splits up the handlers, so the `POST` handler matches `/lease` only, while the `DELETE` handler matches `/lease/`
