### PR TITLE
feat(cli,glide,handlers): implement a lightweight CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 vendor
 k8s-claimer
 rootfs/bin
+cli/bin
+k8s-claimer-cli
+kubeconfig.yaml

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,9 @@ docker-build:
 
 deploy-to-deis:
 	${DEIS_BINARY_NAME} pull ${IMAGE} -a ${DEIS_APP_NAME}
+
+build-cli-cross:
+	${DEV_ENV_CMD} gox -output="cli/bin/${SHORT_NAME}-{{.OS}}-{{.Arch}}"
+
+build-cli:
+	go build -o k8s-claimer-cli ./cli

--- a/api/create_lease.go
+++ b/api/create_lease.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"time"
+)
+
+// CreateLeaseReq is the encoding/json compatible struct that represents the POST /lease
+// request body
+type CreateLeaseReq struct {
+	MaxTimeSec int `json:"max_time"`
+}
+
+// MaxTimeDur returns the maximum time specified in c as a time.Duration
+func (c CreateLeaseReq) MaxTimeDur() time.Duration {
+	return time.Duration(c.MaxTimeSec) * time.Second
+}
+
+// ExpirationTime is a convenience function for start.Add(c.MaxTimeDur())
+func (c CreateLeaseReq) ExpirationTime(start time.Time) time.Time {
+	return start.Add(c.MaxTimeDur())
+}
+
+// CreateLeaseResp is the encoding/json compatible struct that represents the POST /lease
+// response body
+type CreateLeaseResp struct {
+	KubeConfig  string `json:"kubeconfig"`
+	IP          string `json:"ip"`
+	Token       string `json:"uuid"`
+	ClusterName string `json:"cluster_name"`
+}
+
+// DecodeCreateLeaseResp decodes rdr from its JSON representation into a CreateLeaseResp.
+// If there was any error reading rdr or it had malformed JSON, returns nil and the error
+func DecodeCreateLeaseResp(rdr io.Reader) (*CreateLeaseResp, error) {
+	ret := new(CreateLeaseResp)
+	if err := json.NewDecoder(rdr).Decode(ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// DecodeKubeConfig decodes c.KubeConfig by the RFC 4648 standard.
+// See http://tools.ietf.org/html/rfc4648 for more information
+func (c CreateLeaseResp) DecodeKubeConfig() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(c.KubeConfig)
+}

--- a/cli/commands/create_lease.go
+++ b/cli/commands/create_lease.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/deis/k8s-claimer/api"
+	"github.com/deis/k8s-claimer/htp"
+)
+
+const (
+	ipEnvVarName          = "IP"
+	tokenEnvVarName       = "TOKEN"
+	clusterNameEnvVarName = "CLUSTER_NAME"
+)
+
+// CreateLease is a cli.Command action for creating a lease
+func CreateLease(c *cli.Context) {
+	server := c.GlobalString("server")
+	if server == "" {
+		log.Fatalf("Server missing")
+	}
+	durationSec := c.Int("duration")
+	if durationSec <= 0 {
+		log.Fatalf("Invalid duration %d", durationSec)
+	}
+	envPrefix := c.String("env-prefix")
+	kcfgFile := c.String("kubeconfig-file")
+	if len(kcfgFile) < 1 {
+		log.Fatalf("Missing kubeconfig-file")
+	}
+
+	fd, err := os.Create(kcfgFile)
+	if err != nil {
+		log.Fatalf("Error opening %s (%s)", kcfgFile, err)
+	}
+	defer fd.Close()
+
+	endpt := newEndpoint(htp.Post, server, "lease")
+	reqBuf := new(bytes.Buffer)
+	req := api.CreateLeaseReq{MaxTimeSec: durationSec}
+	if err := json.NewEncoder(reqBuf).Encode(req); err != nil {
+		log.Fatalf("Error encoding request body (%s)", err)
+	}
+	res, err := endpt.executeReq(getHTTPClient(), reqBuf)
+	if err != nil {
+		log.Fatalf("Error executing %s (%s)", endpt, err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		log.Fatalf("Error executing %s (status code %d)", endpt, res.StatusCode)
+	}
+
+	decodedRes, err := api.DecodeCreateLeaseResp(res.Body)
+	if err != nil {
+		log.Fatalf("Error decoding response (%s)", err)
+	}
+
+	kcfg, err := decodedRes.DecodeKubeConfig()
+	if err != nil {
+		log.Fatalf("Error decoding kubeconfig (%s)", err)
+	}
+	fmt.Println(exportVar(envPrefix, ipEnvVarName, decodedRes.IP))
+	fmt.Println(exportVar(envPrefix, tokenEnvVarName, decodedRes.Token))
+	fmt.Println(exportVar(envPrefix, clusterNameEnvVarName, decodedRes.ClusterName))
+
+	if _, err := io.Copy(fd, bytes.NewBuffer(kcfg)); err != nil {
+		log.Fatalf("Error writing new Kubeconfig file to %s (%s)", kcfgFile, err)
+	}
+}
+
+func exportVar(prefix, envVarName, val string) string {
+	if prefix != "" {
+		envVarName = fmt.Sprintf("%s_%s", prefix, envVarName)
+	}
+	val = strings.Replace(val, `"`, `\"`, -1)
+	return fmt.Sprintf(`export %s="%s"`, envVarName, val)
+}

--- a/cli/commands/delete_lease.go
+++ b/cli/commands/delete_lease.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/codegangsta/cli"
+	"github.com/deis/k8s-claimer/htp"
+)
+
+// DeleteLease is a cli.Command action for deleting a lease
+func DeleteLease(c *cli.Context) {
+	server := c.GlobalString("server")
+	if server == "" {
+		log.Fatalf("Server missing")
+	}
+	if len(c.Args()) < 1 {
+		log.Fatalf("Lease token missing")
+	}
+	leaseToken := c.Args()[0]
+	endpt := newEndpoint(htp.Delete, server, "lease/"+leaseToken)
+	resp, err := endpt.executeReq(getHTTPClient(), nil)
+	if err != nil {
+		log.Fatalf("Error executing %s (%s)", endpt, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			bodyBytes = nil
+		}
+		log.Fatalf("Error deleting. Code: %d, Body: %s", resp.StatusCode, string(bodyBytes))
+	}
+	fmt.Println("Deleted lease", leaseToken)
+}

--- a/cli/commands/http.go
+++ b/cli/commands/http.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/deis/k8s-claimer/htp"
+)
+
+type endpoint struct {
+	host   string
+	path   string
+	method htp.Method
+}
+
+func newEndpoint(method htp.Method, host, path string) endpoint {
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "http://" + host
+	}
+	if strings.HasPrefix(path, "/") {
+		path = path[1:]
+	}
+	return endpoint{host: host, path: path, method: method}
+}
+
+func (e endpoint) String() string {
+	return fmt.Sprintf("%s %s/%s", e.method, e.host, e.path)
+}
+
+func (e endpoint) httpReq(body io.Reader) (*http.Request, error) {
+	return http.NewRequest(e.method.String(), fmt.Sprintf("%s/%s", e.host, e.path), body)
+}
+
+func (e endpoint) executeReq(cl *http.Client, body io.Reader) (*http.Response, error) {
+	req, err := e.httpReq(body)
+	if err != nil {
+		return nil, err
+	}
+	return cl.Do(req)
+}
+
+func getHTTPClient() *http.Client {
+	return http.DefaultClient
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/deis/k8s-claimer/cli/commands"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "k8s-claimer"
+	app.Usage = "This CLI can be used against a k8s-claimer server to acquire and release leases"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "server",
+			Value: "",
+			Usage: "The k8s-claimer server to talk to",
+		},
+	}
+	app.Commands = []cli.Command{
+		cli.Command{
+			Name: "lease",
+			Subcommands: []cli.Command{
+				cli.Command{
+					Name: "create",
+					Usage: `Creates a new lease and returns 'export' statements to set the lease values as environment variables. Set the 'env-prefix' flag to prefix the environment variable names. If you pass that flag, a '_' character will separate the prefix with the rest of the environment variable name. Below are the basic environment variable names:
+
+- IP - the IP address of the Kubernetes master server
+- TOKEN - contains the lease token. Use this when you run 'k8s-claimer-cli lease delete'
+- CLUSTER_NAME - contains the name of the cluster. For informational purposes only
+
+The Kubeconfig file will be written to kubeconfig-file
+`,
+					Action: commands.CreateLease,
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "duration",
+							Value: 10,
+							Usage: "The duration of the lease in seconds",
+						},
+						cli.StringFlag{
+							Name:  "env-prefix",
+							Value: "",
+							Usage: "The prefix for all environment variables that this command sets",
+						},
+						cli.StringFlag{
+							Name:  "kubeconfig-file",
+							Value: "./kubeconfig.yaml",
+							Usage: "The location of the resulting Kubeconfig file",
+						},
+					},
+				},
+				cli.Command{
+					Name:   "delete",
+					Action: commands.DeleteLease,
+					Usage: `Releases a currently held lease. Pass the lease token as the first and only parameter to this command. For example:
+
+k8s-claimer-cli lease delete $TOKEN
+`,
+				},
+			},
+		},
+	}
+	app.Run(os.Args)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2897899614ccf56f1a2559208be0ce2aa44454890add82b08006eeb2155a6ed1
-updated: 2016-04-13T10:56:56.724950967-07:00
+hash: fa076d88f2f18d9a860926831656d5fe7dc3d2053d9d7db582bc316d5180c660
+updated: 2016-04-21T10:14:50.033357113-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -128,7 +128,7 @@ imports:
   - googleapi
   - googleapi/internal/uritemplates
 - name: google.golang.org/appengine
-  version: b67c870a16a2d58b3afa024461dcc51805f52e9d
+  version: e234e71924d4aa52444bc76f2f831f13fa1eca60
   subpackages:
   - urlfetch
   - internal
@@ -145,6 +145,7 @@ imports:
   - pkg/client/unversioned
   - pkg/api
   - pkg/client/unversioned/clientcmd/api
+  - pkg/labels
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta
@@ -171,12 +172,12 @@ imports:
   - pkg/api/resource
   - pkg/auth/user
   - pkg/conversion
-  - pkg/labels
   - pkg/runtime/serializer
   - pkg/types
   - pkg/util
   - pkg/util/intstr
   - pkg/util/rand
+  - pkg/util/validation
   - pkg/util/validation/field
   - pkg/api/v1
   - pkg/apimachinery
@@ -197,7 +198,6 @@ imports:
   - pkg/conversion/queryparams
   - pkg/util/runtime
   - third_party/forked/reflect
-  - pkg/util/validation
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/versioning

--- a/glide.lock
+++ b/glide.lock
@@ -11,6 +11,8 @@ imports:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
+- name: github.com/codegangsta/cli
+  version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
 - name: github.com/davecgh/go-spew
   version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,4 @@ import:
 - package: k8s.io/kubernetes
   version: ~1.2
 - package: github.com/arschles/assert
+- package: github.com/codegangsta/cli

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/deis/k8s-claimer/api"
 	"github.com/deis/k8s-claimer/clusters"
 	"github.com/deis/k8s-claimer/gke"
 	"github.com/deis/k8s-claimer/htp"
@@ -12,25 +13,6 @@ import (
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/pborman/uuid"
 )
-
-type createLeaseReq struct {
-	MaxTimeSec int `json:"max_time"`
-}
-
-type createLeaseResp struct {
-	KubeConfig  string `json:"kubeconfig"`
-	IP          string `json:"ip"`
-	Token       string `json:"uuid"`
-	ClusterName string `json:"cluster_name"`
-}
-
-func (c createLeaseReq) maxTimeDur() time.Duration {
-	return time.Duration(c.MaxTimeSec) * time.Second
-}
-
-func (c createLeaseReq) expirationTime(start time.Time) time.Time {
-	return start.Add(c.maxTimeDur())
-}
 
 // CreateLease creates the handler that responds to the POST /lease endpoint
 func CreateLease(
@@ -42,7 +24,7 @@ func CreateLease(
 ) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		req := new(createLeaseReq)
+		req := new(api.CreateLeaseReq)
 		if err := json.NewDecoder(r.Body).Decode(req); err != nil {
 			htp.Error(w, http.StatusBadRequest, "error decoding JSON (%s)", err)
 			return
@@ -93,20 +75,21 @@ func CreateLease(
 			)
 			return
 		}
+
 		kubeConfigStr, err := marshalAndEncodeKubeConfig(kubeConfig)
 		if err != nil {
 			htp.Error(w, http.StatusInternalServerError, "error marshaling & encoding kubeconfig (%s)", err)
 			return
 		}
 
-		resp := createLeaseResp{
+		resp := api.CreateLeaseResp{
 			KubeConfig:  kubeConfigStr,
 			IP:          availableCluster.Endpoint,
 			Token:       newToken.String(),
 			ClusterName: availableCluster.Name,
 		}
 
-		leaseMap.CreateLease(newToken, leases.NewLease(availableCluster.Name, req.expirationTime(time.Now())))
+		leaseMap.CreateLease(newToken, leases.NewLease(availableCluster.Name, req.ExpirationTime(time.Now())))
 
 		if err := saveAnnotations(services, svc, leaseMap); err != nil {
 			htp.Error(w, http.StatusInternalServerError, "error saving new lease to Kubernetes annotations (%s)", err)

--- a/handlers/create_lease_test.go
+++ b/handlers/create_lease_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
+	"github.com/deis/k8s-claimer/api"
 	"github.com/deis/k8s-claimer/gke"
 	"github.com/pborman/uuid"
 	container "google.golang.org/api/container/v1"
@@ -52,7 +53,7 @@ func TestCreateLeaseValidResp(t *testing.T) {
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
 	assert.Equal(t, res.Code, http.StatusOK, "response code")
-	leaseResp := new(createLeaseResp)
+	leaseResp := new(api.CreateLeaseResp)
 	assert.NoErr(t, json.NewDecoder(res.Body).Decode(leaseResp))
 	expectedKubeCfg, err := createKubeConfigFromCluster(cluster)
 	assert.NoErr(t, err)

--- a/handlers/create_lease_test.go
+++ b/handlers/create_lease_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deis/k8s-claimer/gke"
 	"github.com/pborman/uuid"
 	container "google.golang.org/api/container/v1"
-	"k8s.io/kubernetes/pkg/api"
+	k8sapi "k8s.io/kubernetes/pkg/api"
 )
 
 func newFakeClusterLister(resp *container.ListClustersResponse, err error) *gke.FakeClusterLister {
@@ -43,8 +43,8 @@ func TestCreateLeaseValidResp(t *testing.T) {
 	clusterLister := newFakeClusterLister(&container.ListClustersResponse{
 		Clusters: []*container.Cluster{cluster},
 	}, nil)
-	services := newFakeServiceGetterUpdater(&api.Service{
-		ObjectMeta: api.ObjectMeta{Name: "service1"},
+	services := newFakeServiceGetterUpdater(&k8sapi.Service{
+		ObjectMeta: k8sapi.ObjectMeta{Name: "service1"},
 	}, nil, nil, nil)
 	hdl := CreateLease(clusterLister, services, "", "", "")
 	reqBody := `{"max_time":30}`


### PR DESCRIPTION
Fixes #34

To test this, pull this code and `make build-cli` it. After that, you can run commands with:

```
./k8s-claimer-cli --server=k8s-claimer-e2e.deis.com lease create # note the lease uuid and set it to LEASE_UUID
./k8s-claimer-cli --server=k8s-claimer-e2e.deis.com lease delete $LEASE_UUID
```
