### PR TITLE
fix(deploy.sh): fix deis automatic deployment

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -13,6 +13,5 @@ DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push
 
 # download deis CLI & deploy to deis
 curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
-mv ./deis /usr/local/bin/deis
-deis login --username=$DEIS_USERNAME --password=$DEIS_PASSWORD deis.k8s-claimer-e2e.deis.com
-DEIS_APP_NAME=k8s-claimer-e2e make deploy-to-deis
+./deis login --username=$DEIS_USERNAME --password=$DEIS_PASSWORD deis.k8s-claimer-e2e.deis.com
+DEIS_APP_NAME=k8s-claimer-e2e make -C .. deploy-to-deis


### PR DESCRIPTION
- Run deploy-to-deis build target against the right makefile
- Don't try to move the deis binary to `/usr/local/bin`. Instead, use it locally
