### PR TITLE
feat(create/delete_lease): add auth token functionality

### DIFF
--- a/cli/commands/create_lease.go
+++ b/cli/commands/create_lease.go
@@ -23,6 +23,11 @@ const (
 
 // CreateLease is a cli.Command action for creating a lease
 func CreateLease(c *cli.Context) {
+	// inspect env for auth env var
+	authToken := os.Getenv("AUTH_TOKEN")
+	if authToken == "" {
+		log.Fatalf("An authorization token is required in the form of an env var AUTH_TOKEN")
+	}
 	server := c.GlobalString("server")
 	if server == "" {
 		log.Fatalf("Server missing")
@@ -49,7 +54,7 @@ func CreateLease(c *cli.Context) {
 	if err := json.NewEncoder(reqBuf).Encode(req); err != nil {
 		log.Fatalf("Error encoding request body (%s)", err)
 	}
-	res, err := endpt.executeReq(getHTTPClient(), reqBuf)
+	res, err := endpt.executeReq(getHTTPClient(), reqBuf, authToken)
 	if err != nil {
 		log.Fatalf("Error executing %s (%s)", endpt, err)
 	}

--- a/cli/commands/delete_lease.go
+++ b/cli/commands/delete_lease.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/deis/k8s-claimer/htp"
@@ -12,6 +13,11 @@ import (
 
 // DeleteLease is a cli.Command action for deleting a lease
 func DeleteLease(c *cli.Context) {
+	// inspect env for auth env var
+	authToken := os.Getenv("AUTH_TOKEN")
+	if authToken == "" {
+		log.Fatalf("An authorization token is required in the form of an env var AUTH_TOKEN")
+	}
 	server := c.GlobalString("server")
 	if server == "" {
 		log.Fatalf("Server missing")
@@ -21,7 +27,7 @@ func DeleteLease(c *cli.Context) {
 	}
 	leaseToken := c.Args()[0]
 	endpt := newEndpoint(htp.Delete, server, "lease/"+leaseToken)
-	resp, err := endpt.executeReq(getHTTPClient(), nil)
+	resp, err := endpt.executeReq(getHTTPClient(), nil, authToken)
 	if err != nil {
 		log.Fatalf("Error executing %s (%s)", endpt, err)
 	}

--- a/cli/commands/http.go
+++ b/cli/commands/http.go
@@ -33,11 +33,12 @@ func (e endpoint) httpReq(body io.Reader) (*http.Request, error) {
 	return http.NewRequest(e.method.String(), fmt.Sprintf("%s/%s", e.host, e.path), body)
 }
 
-func (e endpoint) executeReq(cl *http.Client, body io.Reader) (*http.Response, error) {
+func (e endpoint) executeReq(cl *http.Client, body io.Reader, authToken string) (*http.Response, error) {
 	req, err := e.httpReq(body)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", authToken)
 	return cl.Do(req)
 }
 

--- a/config/server.go
+++ b/config/server.go
@@ -10,6 +10,7 @@ type Server struct {
 	BindPort    int    `envconfig:"BIND_PORT" default:"8080"`
 	Namespace   string `envconfig:"NAMESPACE" default:"k8s-claimer"`
 	ServiceName string `envconfig:"SERVICE_NAME" default:"k8s-claimer"`
+	AuthToken   string `envconfig:"AUTH_TOKEN" required:"true"`
 }
 
 // HostStr returns the full host string for the server, based on s.BindHost and s.BindPort

--- a/handlers/auth_middleware.go
+++ b/handlers/auth_middleware.go
@@ -1,0 +1,14 @@
+package handlers
+
+import "net/http"
+
+// WithAuth provides handling of endpoints requiring authentication
+func WithAuth(tokenToCheck, tokenHeaderName string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(tokenHeaderName) != tokenToCheck {
+			http.Error(w, "not authorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/handlers/delete_lease.go
+++ b/handlers/delete_lease.go
@@ -7,7 +7,7 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/pborman/uuid"
-	api "k8s.io/kubernetes/pkg/api"
+	k8sapi "k8s.io/kubernetes/pkg/api"
 	labels "k8s.io/kubernetes/pkg/labels"
 )
 
@@ -48,7 +48,7 @@ func DeleteLease(services k8s.ServiceGetterUpdater, k8sServiceName string, names
 		}
 
 		// clear all namespaces
-		namespacesList, err := namespaces.List(api.ListOptions{LabelSelector: labels.Everything()})
+		namespacesList, err := namespaces.List(k8sapi.ListOptions{LabelSelector: labels.Everything()})
 		if err != nil {
 			htp.Error(w, http.StatusInternalServerError, "cannot get namespaces (%s)", err)
 			return

--- a/handlers/delete_lease_test.go
+++ b/handlers/delete_lease_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -14,10 +15,13 @@ import (
 )
 
 func TestDeleteLeaseNoToken(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
 	getterUpdater := newFakeServiceGetterUpdater(nil, nil, nil, nil)
 	nsListerDeleter := newFakeNamespaceListerDeleter(nil, nil, nil)
 	hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
 	req, err := http.NewRequest("DELETE", "/lease", nil)
+	req.Header.Set("Authorization", "some awesome token")
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
@@ -25,10 +29,13 @@ func TestDeleteLeaseNoToken(t *testing.T) {
 }
 
 func TestDeleteLeaseInvalidLeaseToken(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
 	getterUpdater := newFakeServiceGetterUpdater(nil, nil, nil, nil)
 	nsListerDeleter := newFakeNamespaceListerDeleter(nil, nil, nil)
 	hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
 	req, err := http.NewRequest("DELETE", "/lease/abcd", nil)
+	req.Header.Set("Authorization", "some awesome token")
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
@@ -36,6 +43,8 @@ func TestDeleteLeaseInvalidLeaseToken(t *testing.T) {
 }
 
 func TestDeleteLeaseInvalidAnnotations(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
 	// Issue a DELETE with a lease token that doesn't point to a valid lease.
 	// Annotations have invalid data in them, which the lease parser should just ignore.
 	getterUpdater := newFakeServiceGetterUpdater(
@@ -47,6 +56,7 @@ func TestDeleteLeaseInvalidAnnotations(t *testing.T) {
 	nsListerDeleter := newFakeNamespaceListerDeleter(nil, nil, nil)
 	hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
 	req, err := http.NewRequest("DELETE", "/lease/"+uuid.New(), nil)
+	req.Header.Set("Authorization", "some awesome token")
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
@@ -54,6 +64,8 @@ func TestDeleteLeaseInvalidAnnotations(t *testing.T) {
 }
 
 func TestDeleteLeaseNoSuchLease(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
 	getterUpdater := newFakeServiceGetterUpdater(
 		&api.Service{ObjectMeta: api.ObjectMeta{Annotations: map[string]string{}}},
 		nil,
@@ -63,13 +75,56 @@ func TestDeleteLeaseNoSuchLease(t *testing.T) {
 	nsListerDeleter := newFakeNamespaceListerDeleter(nil, nil, nil)
 	hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
 	req, err := http.NewRequest("DELETE", "/lease/"+uuid.New(), nil)
+	req.Header.Set("Authorization", "some awesome token")
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
 	hdl.ServeHTTP(res, req)
 	assert.Equal(t, res.Code, http.StatusConflict, "response code")
 }
 
+func TestDeleteLeaseInvalidAuth(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
+	clusterNames := []string{"cluster1"}
+	uuids := make([]uuid.UUID, len(clusterNames))
+	annos := testutil.GetRawAnnotations(
+		clusterNames,
+		leases.TimeFormat,
+		func(i int) time.Time {
+			return time.Now().Add(1 * time.Hour)
+		},
+		func(i int) uuid.UUID {
+			ret := uuid.NewUUID()
+			uuids[i] = ret
+			return ret
+		},
+	)
+	getterUpdater := newFakeServiceGetterUpdater(
+		&api.Service{ObjectMeta: api.ObjectMeta{Annotations: annos}},
+		nil,
+		nil,
+		nil,
+	)
+	path := "/lease/" + uuids[0].String()
+	namespaces := []string{"ns1", "ns2"}
+	nsList := api.NamespaceList{}
+	for _, namespace := range namespaces {
+		nsList.Items = append(nsList.Items, api.Namespace{ObjectMeta: api.ObjectMeta{Name: namespace}})
+	}
+	nsListerDeleter := newFakeNamespaceListerDeleter(
+		&nsList, nil, nil)
+	hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
+	req, err := http.NewRequest("DELETE", path, nil)
+	req.Header.Set("Authorization", "different token")
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	hdl.ServeHTTP(res, req)
+	assert.Equal(t, res.Code, http.StatusUnauthorized, "response code")
+}
+
 func TestDeleteLeaseExists(t *testing.T) {
+	os.Setenv("AUTH_TOKEN", "some awesome token")
+	defer os.Clearenv()
 	clusterNames := []string{"cluster1", "cluster2"}
 	uuids := make([]uuid.UUID, len(clusterNames))
 	annos := testutil.GetRawAnnotations(
@@ -103,6 +158,7 @@ func TestDeleteLeaseExists(t *testing.T) {
 			&nsList, nil, nil)
 		hdl := DeleteLease(getterUpdater, "claimer", nsListerDeleter)
 		req, err := http.NewRequest("DELETE", path, nil)
+		req.Header.Set("Authorization", "some awesome token")
 		if err != nil {
 			t.Errorf("trial %d: error creating request %s (%s)", i, path, err)
 			continue


### PR DESCRIPTION
For create and delete lease cli commands/handlers to use before
processing requests.
