### PR TITLE
fix(Makefile): build-cli-cross was not using cli path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ deploy-to-deis:
 	${DEIS_BINARY_NAME} pull ${IMAGE} -a ${DEIS_APP_NAME}
 
 build-cli-cross:
-	${DEV_ENV_CMD} gox -output="cli/bin/${SHORT_NAME}-${VERSION}-{{.OS}}-{{.Arch}}"
+	${DEV_ENV_CMD} gox -output="cli/bin/${SHORT_NAME}-cli_${VERSION}_{{.OS}}-{{.Arch}}" ./cli
 
 prep-bintray-json:
 	@jq '.version.name |= "$(VERSION)"' _scripts/ci/bintray-template.json \


### PR DESCRIPTION
We were producing binaries for the k8s-claimer server not the CLI
fixes #59
