### PR TITLE
fix(GKE): Output yaml instead of json for kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include versioning.mk
 VERSION ?= git-$(shell git rev-parse --short HEAD)
 LDFLAGS := "-s -X main.version=${VERSION}"
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: fa076d88f2f18d9a860926831656d5fe7dc3d2053d9d7db582bc316d5180c660
-updated: 2016-04-21T10:14:50.033357113-07:00
+hash: 2d232723e74809af7dc662b7da5a2f1537582c474eb3cef63e7e18c4ed96b2c0
+updated: 2016-05-17T10:38:04.76089223-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
 - name: github.com/arschles/assert
-  version: d21ecd4884be33397d1298c3738b2b4937c7f499
+  version: 5c22e2eba944d89ddd5c81b2c4175e64ee828503
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
@@ -12,30 +12,50 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
-  version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
+  version: 0eb4e0be6c214f8904ef6989b11072c7b897c657
 - name: github.com/davecgh/go-spew
-  version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/docker/docker
-  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
-  - pkg/jsonmessage
-  - pkg/mount
-  - pkg/parsers
-  - pkg/symlink
-  - pkg/term
-  - pkg/timeutils
-  - pkg/units
-- name: github.com/docker/go-units
-  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
+  - digest
+  - reference
 - name: github.com/emicklei/go-restful
-  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
+  version: 496d495156da218b9912f03dfa7df7f80fbd8cc3
   subpackages:
-  - swagger
   - log
+  - swagger
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - gogoproto
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/grpc
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
+  - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/plugin
+  - sortkeys
+  - vanity
+  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
@@ -43,24 +63,40 @@ imports:
   subpackages:
   - proto
 - name: github.com/google/cadvisor
-  version: 546a3771589bdb356777c646c6eca24914fdd48b
+  version: 750f18e5eac3f6193b354fc14c03d92d4318a0ec
   subpackages:
   - api
   - cache/memory
   - collector
   - container
+  - container/common
+  - container/docker
+  - container/libcontainer
+  - container/raw
+  - container/rkt
+  - container/systemd
   - events
   - fs
   - healthz
   - http
+  - http/mux
   - info/v1
+  - info/v1/test
   - info/v2
   - manager
   - metrics
   - pages
+  - pages/static
   - storage
   - summary
   - utils
+  - utils/cloudinfo
+  - utils/cpuload
+  - utils/cpuload/netlink
+  - utils/machine
+  - utils/oomparser
+  - utils/sysfs
+  - utils/sysinfo
   - validate
   - version
 - name: github.com/google/gofuzz
@@ -68,19 +104,11 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: cea086319492c3940683ea5e122aa5de70a33923
+  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
-- name: github.com/opencontainers/runc
-  version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
-  subpackages:
-  - libcontainer
-  - libcontainer/cgroups/fs
-  - libcontainer/configs
-  - libcontainer/cgroups
-  - libcontainer/system
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/prometheus/client_golang
@@ -104,22 +132,27 @@ imports:
   version: f4485b318aadd133842532f841dc205a8e339d74
   subpackages:
   - codec
+  - codec/codecgen
 - name: golang.org/x/net
   version: c2528b2dd8352441850638a8bb678c2ad056fd3e
   subpackages:
   - context
+  - context/ctxhttp
   - html
+  - html/atom
   - http2
+  - http2/hpack
   - internal/timeseries
+  - proxy
   - trace
   - websocket
-  - context/ctxhttp
 - name: golang.org/x/oauth2
   version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
   subpackages:
-  - jwt
+  - google
   - internal
   - jws
+  - jwt
 - name: google.golang.org/api
   version: 77e7d383beb96054547729f49c372b3d01e196ff
   subpackages:
@@ -127,20 +160,17 @@ imports:
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
-- name: google.golang.org/appengine
-  version: e234e71924d4aa52444bc76f2f831f13fa1eca60
+- name: google.golang.org/cloud
+  version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
   subpackages:
-  - urlfetch
+  - compute/metadata
   - internal
-  - internal/urlfetch
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/remote_api
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: d466437aa4adc35830964cffc5b5f262c63ddcb4
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: k8s.io/kubernetes
-  version: 487e70173625fe7e33b28e7989735b496d86fe01
+  version: a24f03c3c99bd305ace7745b7a5749790be060e3
   subpackages:
   - pkg/client/unversioned
   - pkg/api
@@ -151,15 +181,21 @@ imports:
   - pkg/api/meta
   - pkg/api/unversioned
   - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/authentication.k8s.io/install
   - pkg/apis/authorization/install
   - pkg/apis/autoscaling
   - pkg/apis/autoscaling/install
   - pkg/apis/batch
   - pkg/apis/batch/install
+  - pkg/apis/batch/v2alpha1
   - pkg/apis/componentconfig/install
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/metrics/install
+  - pkg/apis/policy
+  - pkg/apis/policy/install
   - pkg/client/restclient
   - pkg/client/typed/discovery
   - pkg/fields
@@ -169,6 +205,7 @@ imports:
   - pkg/util/wait
   - pkg/version
   - pkg/watch
+  - plugin/pkg/client/auth
   - pkg/api/resource
   - pkg/auth/user
   - pkg/conversion
@@ -182,37 +219,47 @@ imports:
   - pkg/api/v1
   - pkg/apimachinery
   - pkg/util/errors
+  - pkg/apis/apps/v1alpha1
+  - pkg/apis/authentication.k8s.io
+  - pkg/apis/authentication.k8s.io/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling/v1
   - pkg/apis/batch/v1
+  - pkg/watch/versioned
   - pkg/apis/componentconfig
   - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions/v1beta1
   - pkg/apis/metrics
   - pkg/apis/metrics/v1alpha1
+  - pkg/apis/policy/v1alpha1
   - pkg/api/validation
   - pkg/client/metrics
   - pkg/client/transport
-  - pkg/watch/json
+  - pkg/runtime/serializer/streaming
+  - pkg/util/crypto
+  - pkg/util/flowcontrol
   - pkg/conversion/queryparams
+  - pkg/util/json
   - pkg/util/runtime
+  - plugin/pkg/client/auth/gcp
   - third_party/forked/reflect
   - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/versioning
-  - pkg/util/integer
   - pkg/util/parsers
   - pkg/kubelet/qos
   - pkg/master/ports
   - pkg/api/endpoints
   - pkg/api/pod
   - pkg/api/service
+  - pkg/api/unversioned/validation
   - pkg/api/util
   - pkg/capabilities
   - pkg/util/yaml
+  - pkg/util/integer
+  - pkg/util/framer
   - pkg/util/hash
   - pkg/util/net/sets
-- name: speter.net/go/exp/math/dec/inf
-  version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,6 @@ import:
   subpackages:
   - container/v1
 - package: k8s.io/kubernetes
-  version: ~1.2
+  version: a24f03c3c99bd305ace7745b7a5749790be060e3
 - package: github.com/arschles/assert
 - package: github.com/codegangsta/cli

--- a/handlers/gke.go
+++ b/handlers/gke.go
@@ -2,13 +2,13 @@ package handlers
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"strings"
 
 	"github.com/deis/k8s-claimer/clusters"
 	"github.com/deis/k8s-claimer/leases"
 	container "google.golang.org/api/container/v1"
+	"gopkg.in/yaml.v2"
 	k8scmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
@@ -67,9 +67,9 @@ func createKubeConfigFromCluster(cluster *container.Cluster) (*k8scmd.Config, er
 }
 
 func marshalAndEncodeKubeConfig(cfg *k8scmd.Config) (string, error) {
-	cfgBytes, err := json.Marshal(cfg)
+	y, err := yaml.Marshal(cfg)
 	if err != nil {
 		return "", err
 	}
-	return base64.StdEncoding.EncodeToString(cfgBytes), nil
+	return base64.StdEncoding.EncodeToString(y), nil
 }

--- a/handlers/gke_test.go
+++ b/handlers/gke_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/deis/k8s-claimer/testutil"
 	"github.com/pborman/uuid"
 	container "google.golang.org/api/container/v1"
+	"gopkg.in/yaml.v2"
 	k8scmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
@@ -156,7 +156,7 @@ func TestMarshalAndEncodeKubeConfig(t *testing.T) {
 	decodedBytes, err := base64.StdEncoding.DecodeString(str)
 	assert.NoErr(t, err)
 	decodedCfg := new(k8scmd.Config)
-	assert.NoErr(t, json.Unmarshal(decodedBytes, decodedCfg))
+	assert.NoErr(t, yaml.Unmarshal(decodedBytes, decodedCfg))
 	assert.Equal(t, decodedCfg.APIVersion, cfg.APIVersion, "API version")
 
 }


### PR DESCRIPTION
For some reason kubectl doesnt like json anymore. So instead of outputting that format we should just switch to yaml.
