### PR TITLE
fix(cli): remove deprecation notice on cli actions

### DIFF
--- a/cli/commands/delete_lease.go
+++ b/cli/commands/delete_lease.go
@@ -12,32 +12,39 @@ import (
 )
 
 // DeleteLease is a cli.Command action for deleting a lease
-func DeleteLease(c *cli.Context) {
+func DeleteLease(c *cli.Context) error {
 	// inspect env for auth env var
 	authToken := os.Getenv("AUTH_TOKEN")
 	if authToken == "" {
 		log.Fatalf("An authorization token is required in the form of an env var AUTH_TOKEN")
+		return errMissingAuthToken
 	}
 	server := c.GlobalString("server")
 	if server == "" {
 		log.Fatalf("Server missing")
+		return errMissingServer
 	}
 	if len(c.Args()) < 1 {
 		log.Fatalf("Lease token missing")
+		return errMissingLeaseToken
 	}
 	leaseToken := c.Args()[0]
 	endpt := newEndpoint(htp.Delete, server, "lease/"+leaseToken)
 	resp, err := endpt.executeReq(getHTTPClient(), nil, authToken)
 	if err != nil {
 		log.Fatalf("Error executing %s (%s)", endpt, err)
+		return errHTTPRequest{endpoint: endpt.String(), err: err}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			bodyBytes = nil
+			return err
 		}
 		log.Fatalf("Error deleting. Code: %d, Body: %s", resp.StatusCode, string(bodyBytes))
+		return errInvalidStatusCode{endpoint: endpt.String(), code: resp.StatusCode}
 	}
 	fmt.Println("Deleted lease", leaseToken)
+	return nil
 }

--- a/cli/commands/errors.go
+++ b/cli/commands/errors.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errMissingAuthToken      = errors.New("missing AUTH_TOKEN")
+	errMissingLeaseToken     = errors.New("missing lease token")
+	errMissingServer         = errors.New("missing IP")
+	errMissingKubeConfigFile = errors.New("missing kubeconfig file")
+)
+
+type errInvalidStatusCode struct {
+	endpoint string
+	code     int
+}
+
+func (e errInvalidStatusCode) Error() string {
+	return fmt.Sprintf("invalid status code for endpoing (%s): %d", e.endpoint, e.code)
+}
+
+type errHTTPRequest struct {
+	endpoint string
+	err      error
+}
+
+func (e errHTTPRequest) Error() string {
+	return fmt.Sprintf("error executing HTTP request on %s (%s)", e.endpoint, e.err)
+}


### PR DESCRIPTION
By using func(*cli.Context) error, the CLI library removes deprecation notices.

Fixes #66 
