### PR TITLE
feat(*): Allow the ability to claim a cluster by name

### DIFF
--- a/api/create_lease.go
+++ b/api/create_lease.go
@@ -10,7 +10,8 @@ import (
 // CreateLeaseReq is the encoding/json compatible struct that represents the POST /lease
 // request body
 type CreateLeaseReq struct {
-	MaxTimeSec int `json:"max_time"`
+	MaxTimeSec   int    `json:"max_time"`
+	ClusterRegex string `json:"cluster_regex"`
 }
 
 // MaxTimeDur returns the maximum time specified in c as a time.Duration

--- a/cli/commands/create_lease.go
+++ b/cli/commands/create_lease.go
@@ -39,6 +39,7 @@ func CreateLease(c *cli.Context) error {
 		log.Fatalf("Invalid duration %d", durationSec)
 	}
 	envPrefix := c.String("env-prefix")
+	clusterRegex := c.String("cluster-regex")
 	kcfgFile := c.String("kubeconfig-file")
 	if len(kcfgFile) < 1 {
 		log.Fatalf("Missing kubeconfig-file")
@@ -54,7 +55,7 @@ func CreateLease(c *cli.Context) error {
 
 	endpt := newEndpoint(htp.Post, server, "lease")
 	reqBuf := new(bytes.Buffer)
-	req := api.CreateLeaseReq{MaxTimeSec: durationSec}
+	req := api.CreateLeaseReq{MaxTimeSec: durationSec, ClusterRegex: clusterRegex}
 	if encErr := json.NewEncoder(reqBuf).Encode(req); encErr != nil {
 		log.Fatalf("Error encoding request body (%s)", err)
 		return err

--- a/cli/main.go
+++ b/cli/main.go
@@ -49,6 +49,11 @@ The Kubeconfig file will be written to kubeconfig-file
 							Value: "./kubeconfig.yaml",
 							Usage: "The location of the resulting Kubeconfig file",
 						},
+						cli.StringFlag{
+							Name:  "cluster-regex",
+							Value: "",
+							Usage: "A regular expression that will be used to match which cluster you lease",
+						},
 					},
 				},
 				cli.Command{

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: 2d232723e74809af7dc662b7da5a2f1537582c474eb3cef63e7e18c4ed96b2c0
-updated: 2016-05-17T10:38:04.76089223-06:00
+hash: 362dcdd3a16ca56fcd1d97bc6f85d3952c86c26b7146c7f7dc263c4d167fd01e
+updated: 2016-08-22T10:09:28.930931963-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
+- name: cloud.google.com/go
+  version: e977e3911f5ba211c715d40c30fc81abfa9400ae
+  subpackages:
+  - container
 - name: github.com/arschles/assert
-  version: 5c22e2eba944d89ddd5c81b2c4175e64ee828503
+  version: fc2da9844984ce5093111298174706e14d4c0c47
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
@@ -12,7 +16,7 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
-  version: 0eb4e0be6c214f8904ef6989b11072c7b897c657
+  version: 168c95418e66e019fe17b8f4f5c45aa62ff80e23
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -104,7 +108,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: 91921eb4cf999321cdbeebdba5a03555800d493b
+  version: 1e291572dcb9ba673cdcdb15e0f422702415ebaf
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
@@ -156,6 +160,8 @@ imports:
 - name: google.golang.org/api
   version: 77e7d383beb96054547729f49c372b3d01e196ff
   subpackages:
+  - cloudmonitoring/v2beta2
+  - compute/v1
   - container/v1
   - gensupport
   - googleapi
@@ -174,8 +180,9 @@ imports:
   subpackages:
   - pkg/client/unversioned
   - pkg/api
-  - pkg/client/unversioned/clientcmd/api
+  - pkg/client/restclient
   - pkg/labels
+  - pkg/runtime
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta
@@ -196,10 +203,8 @@ imports:
   - pkg/apis/metrics/install
   - pkg/apis/policy
   - pkg/apis/policy/install
-  - pkg/client/restclient
   - pkg/client/typed/discovery
   - pkg/fields
-  - pkg/runtime
   - pkg/util/net
   - pkg/util/sets
   - pkg/util/wait
@@ -214,11 +219,21 @@ imports:
   - pkg/util
   - pkg/util/intstr
   - pkg/util/rand
-  - pkg/util/validation
-  - pkg/util/validation/field
   - pkg/api/v1
-  - pkg/apimachinery
+  - pkg/api/validation
+  - pkg/client/metrics
+  - pkg/client/transport
+  - pkg/client/unversioned/clientcmd/api
+  - pkg/runtime/serializer/streaming
+  - pkg/util/crypto
+  - pkg/util/flowcontrol
+  - pkg/watch/versioned
+  - pkg/util/validation
+  - pkg/conversion/queryparams
   - pkg/util/errors
+  - pkg/util/json
+  - pkg/util/validation/field
+  - pkg/apimachinery
   - pkg/apis/apps/v1alpha1
   - pkg/apis/authentication.k8s.io
   - pkg/apis/authentication.k8s.io/v1beta1
@@ -226,21 +241,12 @@ imports:
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling/v1
   - pkg/apis/batch/v1
-  - pkg/watch/versioned
   - pkg/apis/componentconfig
   - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions/v1beta1
   - pkg/apis/metrics
   - pkg/apis/metrics/v1alpha1
   - pkg/apis/policy/v1alpha1
-  - pkg/api/validation
-  - pkg/client/metrics
-  - pkg/client/transport
-  - pkg/runtime/serializer/streaming
-  - pkg/util/crypto
-  - pkg/util/flowcontrol
-  - pkg/conversion/queryparams
-  - pkg/util/json
   - pkg/util/runtime
   - plugin/pkg/client/auth/gcp
   - third_party/forked/reflect
@@ -249,8 +255,6 @@ imports:
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/versioning
   - pkg/util/parsers
-  - pkg/kubelet/qos
-  - pkg/master/ports
   - pkg/api/endpoints
   - pkg/api/pod
   - pkg/api/service
@@ -259,6 +263,8 @@ imports:
   - pkg/capabilities
   - pkg/util/yaml
   - pkg/util/integer
+  - pkg/kubelet/qos
+  - pkg/master/ports
   - pkg/util/framer
   - pkg/util/hash
   - pkg/util/net/sets

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,9 +2,9 @@ package: github.com/deis/k8s-claimer
 import:
 - package: github.com/kelseyhightower/envconfig
 - package: github.com/pborman/uuid
-- package: google.golang.org/api
+- package: cloud.google.com/go
   subpackages:
-  - container/v1
+  - container
 - package: k8s.io/kubernetes
   version: a24f03c3c99bd305ace7745b7a5749790be060e3
 - package: github.com/arschles/assert

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -102,7 +102,7 @@ func CreateLease(
 			return
 		}
 
-		availableCluster, err := searchForFreeCluster(clusterMap, leaseMap)
+		availableCluster, err := searchForFreeCluster(clusterMap, leaseMap, req.ClusterRegex)
 		if err != nil {
 			switch e := err.(type) {
 			case errNoAvailableOrExpiredClustersFound:

--- a/handlers/gke_test.go
+++ b/handlers/gke_test.go
@@ -44,7 +44,7 @@ func TestFindUnusedGKECluster(t *testing.T) {
 	)
 	leaseMap, err := leases.ParseMapFromAnnotations(rawAnnotations)
 	assert.NoErr(t, err)
-	unusedCluster, err := findUnusedGKECluster(clusterMap, leaseMap)
+	unusedCluster, err := findUnusedGKECluster(clusterMap, leaseMap, "")
 	assert.True(t, unusedCluster == nil, "unused cluster returned non-nil when all clusters were in use")
 	assert.Err(t, errUnusedGKEClusterNotFound, err)
 
@@ -62,7 +62,10 @@ func TestFindUnusedGKECluster(t *testing.T) {
 	deleted := leaseMap.DeleteLease(freedUUID)
 	assert.True(t, deleted, "lease for cluster %s was not deleted", freedLease.ClusterName)
 
-	unusedCluster, err = findUnusedGKECluster(clusterMap, leaseMap)
+	// Test leasing a cluster by Name
+	// We will use the name of the freedCluster to lease it again
+	// This should help us from creating a leaky test
+	unusedCluster, err = findUnusedGKECluster(clusterMap, leaseMap, freedLease.ClusterName)
 	assert.NoErr(t, err)
 	assert.Equal(t, unusedCluster.Name, freedLease.ClusterName, "free cluster name")
 }

--- a/handlers/search_free_cluster.go
+++ b/handlers/search_free_cluster.go
@@ -22,14 +22,14 @@ func (e errExpiredLeaseGKEMissing) Error() string {
 	return fmt.Sprintf("cluster %s has an expired lease but does not exist in GKE", e.clusterName)
 }
 
-// searchForFreeCluster first looks in GKE first for a GKE cluster that has no lease associated
-// with it and returns it.
+// searchForFreeCluster looks for an available GKE cluster to lease.
+// It will try and match clusterRegex if possible
 //
 // Returns errNoAvailableOrExpiredClustersFound if it found no free or expired lease clusters.
 // Returns errExpiredLeaseGKEMissing if it found an expired lease but the cluster associated with
 // that lease doesn't exist in GKE
-func searchForFreeCluster(clusterMap *clusters.Map, leaseMap *leases.Map) (*container.Cluster, error) {
-	unusedCluster, unusedClusterErr := findUnusedGKECluster(clusterMap, leaseMap)
+func searchForFreeCluster(clusterMap *clusters.Map, leaseMap *leases.Map, clusterRegex string) (*container.Cluster, error) {
+	unusedCluster, unusedClusterErr := findUnusedGKECluster(clusterMap, leaseMap, clusterRegex)
 	uuidAndLease, expiredLeaseErr := findExpiredLease(leaseMap)
 	if unusedClusterErr != nil && expiredLeaseErr != nil {
 		return nil, errNoAvailableOrExpiredClustersFound{}

--- a/handlers/search_free_cluster_test.go
+++ b/handlers/search_free_cluster_test.go
@@ -21,7 +21,7 @@ func TestSearchForFreeClusterNoneAvailable(t *testing.T) {
 	clusterLister := gke.FakeClusterLister{Err: nil, Resp: &container.ListClustersResponse{Clusters: nil}}
 	clusterMap, err := clusters.ParseMapFromGKE(clusterLister, "", "")
 	assert.NoErr(t, err)
-	cluster, err := searchForFreeCluster(clusterMap, leaseMap)
+	cluster, err := searchForFreeCluster(clusterMap, leaseMap, "")
 	assert.Nil(t, cluster, "cluster")
 	switch tErr := err.(type) {
 	case errNoAvailableOrExpiredClustersFound:
@@ -43,7 +43,7 @@ func TestSearchForClusterNoLeaseFound(t *testing.T) {
 	}
 	clusterMap, err := clusters.ParseMapFromGKE(clusterLister, "", "")
 	assert.NoErr(t, err)
-	cluster, err := searchForFreeCluster(clusterMap, leaseMap)
+	cluster, err := searchForFreeCluster(clusterMap, leaseMap, "")
 	assert.Nil(t, cluster, "cluster")
 	switch tErr := err.(type) {
 	case errExpiredLeaseGKEMissing:


### PR DESCRIPTION
- closes #71
- When claiming a cluster by name you can specify that as a regular expression using the --cluster-regex flag.
- When trying to claim a cluster it will try to fetch a random cluster. This is tried 10 times before it will fail.

If you want to test this manually (which is more than welcomed) please let me know in slack and I will get you the appropriate information.
