### PR TITLE
fix(search_free_clsuter): Always delete lease even if cluster isnt found

### DIFF
--- a/handlers/search_free_cluster.go
+++ b/handlers/search_free_cluster.go
@@ -32,10 +32,6 @@ func searchForFreeCluster(clusterMap *clusters.Map, leaseMap *leases.Map, cluste
 	uuidAndLeases, expiredLeaseErr := findExpiredLeases(leaseMap)
 	if expiredLeaseErr == nil {
 		for _, expiredLease := range uuidAndLeases {
-			_, ok := clusterMap.ClusterByName(expiredLease.Lease.ClusterName)
-			if !ok {
-				return nil, errExpiredLeaseGKEMissing{clusterName: expiredLease.Lease.ClusterName}
-			}
 			leaseMap.DeleteLease(expiredLease.UUID)
 		}
 	}

--- a/handlers/search_free_cluster_test.go
+++ b/handlers/search_free_cluster_test.go
@@ -45,10 +45,5 @@ func TestSearchForClusterNoLeaseFound(t *testing.T) {
 	assert.NoErr(t, err)
 	cluster, err := searchForFreeCluster(clusterMap, leaseMap, "", "")
 	assert.Nil(t, cluster, "cluster")
-	switch tErr := err.(type) {
-	case errExpiredLeaseGKEMissing:
-		assert.Equal(t, tErr.clusterName, clusterName, "cluster name")
-	default:
-		t.Fatalf("returned error was not a errExpiredLeaseGKEMissing (it was a %s)", reflect.TypeOf(tErr))
-	}
+	assert.Err(t, errNoAvailableOrExpiredClustersFound{}, err)
 }


### PR DESCRIPTION
So we have been seeing 500 errors in e2e tests the last few weeks. These events normally happen at night after the clusterator delete job runs. After adding some debug logging it seems that this occurs when we have a lease for a cluster that we have removed from GKE. Instead of only deleting cluster leases if the GKE cluster is still available we remove all leases regardless of cluster state.
