### PR TITLE
chore(cli): Add semver to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHORT_NAME ?= k8s-claimer
 
 include versioning.mk
 
-VERSION ?= git-$(shell git rev-parse --short HEAD)
 LDFLAGS := -ldflags "-s -X main.version=${VERSION}"
 REPO_PATH := github.com/deis/${SHORT_NAME}
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
@@ -43,6 +42,6 @@ else
 endif
 
 build-cli:
-	go build -o k8s-claimer-cli ./cli
+	go build ${LDFLAGS} -o k8s-claimer-cli ./cli
 
 dist: build-cli-cross

--- a/cli/main.go
+++ b/cli/main.go
@@ -7,9 +7,13 @@ import (
 	"github.com/deis/k8s-claimer/cli/commands"
 )
 
+// This value is overwritten by the linker during build.
+var version = "dev"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "k8s-claimer"
+	app.Version = version
 	app.Usage = "This CLI can be used against a k8s-claimer server to acquire and release leases"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,5 +1,5 @@
 MUTABLE_VERSION ?= canary
-VERSION ?= git-$(shell git rev-parse --short HEAD)
+VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo "git-$$(git rev-parse --short HEAD)")
 
 IMAGE_PREFIX ?= deis
 IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}


### PR DESCRIPTION
This adds semantic versioning (based on git tag) to k8s-claimer. This will allow other Docker builds that reference it (e.g. e2e-runner or go-dev) to pick a version by semver instead of an opaque git sha.
