### PR TITLE
Official k8s client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ BINARY_NAME := k8s-claimer
 bootstrap:
 	${DEV_ENV_CMD} glide install
 
+glideup:
+	${DEV_ENV_CMD} glide up
+
 build:
 	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo ${LDFLAGS} -o rootfs/bin/boot
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include versioning.mk
 
 LDFLAGS := -ldflags "-s -X main.version=${VERSION}"
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.19.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/glide.lock
+++ b/glide.lock
@@ -1,271 +1,54 @@
-hash: 362dcdd3a16ca56fcd1d97bc6f85d3952c86c26b7146c7f7dc263c4d167fd01e
-updated: 2016-08-22T10:09:28.930931963-04:00
+hash: db431d842e9f7ef8d705f8e29fdb85d360aa12e8f5c1004e73c7da1b096ffb91
+updated: 2016-09-27T01:47:55.033446276Z
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
 - name: cloud.google.com/go
-  version: e977e3911f5ba211c715d40c30fc81abfa9400ae
+  version: a706b12721e2301f4f2f9045c116f61eb95669eb
   subpackages:
   - container
 - name: github.com/arschles/assert
   version: fc2da9844984ce5093111298174706e14d4c0c47
-- name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
-  subpackages:
-  - quantile
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
-  version: 168c95418e66e019fe17b8f4f5c45aa62ff80e23
-- name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
-  subpackages:
-  - spew
-- name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
-  subpackages:
-  - digest
-  - reference
-- name: github.com/emicklei/go-restful
-  version: 496d495156da218b9912f03dfa7df7f80fbd8cc3
-  subpackages:
-  - log
-  - swagger
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/gogo/protobuf
-  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
-  subpackages:
-  - gogoproto
-  - plugin/defaultcheck
-  - plugin/description
-  - plugin/embedcheck
-  - plugin/enumstringer
-  - plugin/equal
-  - plugin/face
-  - plugin/gostring
-  - plugin/grpc
-  - plugin/marshalto
-  - plugin/oneofcheck
-  - plugin/populate
-  - plugin/size
-  - plugin/stringer
-  - plugin/testgen
-  - plugin/union
-  - plugin/unmarshal
-  - proto
-  - protoc-gen-gogo/descriptor
-  - protoc-gen-gogo/generator
-  - protoc-gen-gogo/plugin
-  - sortkeys
-  - vanity
-  - vanity/command
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
 - name: github.com/golang/protobuf
-  version: b982704f8bb716bb608144408cff30e15fbde841
+  version: 87c000235d3d852c1628dc9490cd21ab36a7d69f
   subpackages:
   - proto
-- name: github.com/google/cadvisor
-  version: 750f18e5eac3f6193b354fc14c03d92d4318a0ec
-  subpackages:
-  - api
-  - cache/memory
-  - collector
-  - container
-  - container/common
-  - container/docker
-  - container/libcontainer
-  - container/raw
-  - container/rkt
-  - container/systemd
-  - events
-  - fs
-  - healthz
-  - http
-  - http/mux
-  - info/v1
-  - info/v1/test
-  - info/v2
-  - manager
-  - metrics
-  - pages
-  - pages/static
-  - storage
-  - summary
-  - utils
-  - utils/cloudinfo
-  - utils/cpuload
-  - utils/cpuload/netlink
-  - utils/machine
-  - utils/oomparser
-  - utils/sysfs
-  - utils/sysinfo
-  - validate
-  - version
-- name: github.com/google/gofuzz
-  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
-- name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: 1e291572dcb9ba673cdcdb15e0f422702415ebaf
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-  subpackages:
-  - pbutil
+  version: 13674b2d056fb658a00ba3f36e78043ced07c924
 - name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
-- name: github.com/prometheus/client_golang
-  version: 3b78d7a77f51ccbc364d4bc170920153022cfd08
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: ef7a9a5fb138aa5d3a19988537606226869a0390
-  subpackages:
-  - expfmt
-  - model
-- name: github.com/prometheus/procfs
-  version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
-- name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
-- name: github.com/ugorji/go
-  version: f4485b318aadd133842532f841dc205a8e339d74
-  subpackages:
-  - codec
-  - codec/codecgen
+  version: b984ec7fa9ff9e428bd0cf0abf429384dfbe3e37
 - name: golang.org/x/net
-  version: c2528b2dd8352441850638a8bb678c2ad056fd3e
+  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
   subpackages:
   - context
   - context/ctxhttp
-  - html
-  - html/atom
-  - http2
-  - http2/hpack
-  - internal/timeseries
-  - proxy
-  - trace
-  - websocket
 - name: golang.org/x/oauth2
-  version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
-  - google
   - internal
   - jws
   - jwt
 - name: google.golang.org/api
-  version: 77e7d383beb96054547729f49c372b3d01e196ff
+  version: 61b3555d21f4bcfe09ddf8595c884424bc8a4ada
   subpackages:
-  - cloudmonitoring/v2beta2
-  - compute/v1
   - container/v1
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
-- name: google.golang.org/cloud
-  version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
+- name: google.golang.org/appengine
+  version: 8d4efd07a9358ec8c7e75b29387c31a7692db8d2
   subpackages:
-  - compute/metadata
   - internal
-- name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
-- name: k8s.io/kubernetes
-  version: a24f03c3c99bd305ace7745b7a5749790be060e3
+  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
+- name: k8s.io/client-go
+  version: 0b62e254fe853d89b1d8d3445bbdab11bcc11bc3
   subpackages:
-  - pkg/client/unversioned
-  - pkg/api
-  - pkg/client/restclient
-  - pkg/labels
-  - pkg/runtime
-  - pkg/api/errors
-  - pkg/api/install
-  - pkg/api/meta
-  - pkg/api/unversioned
-  - pkg/apimachinery/registered
-  - pkg/apis/apps
-  - pkg/apis/apps/install
-  - pkg/apis/authentication.k8s.io/install
-  - pkg/apis/authorization/install
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
-  - pkg/apis/batch
-  - pkg/apis/batch/install
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/componentconfig/install
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/metrics/install
-  - pkg/apis/policy
-  - pkg/apis/policy/install
-  - pkg/client/typed/discovery
-  - pkg/fields
-  - pkg/util/net
-  - pkg/util/sets
-  - pkg/util/wait
-  - pkg/version
-  - pkg/watch
-  - plugin/pkg/client/auth
-  - pkg/api/resource
-  - pkg/auth/user
-  - pkg/conversion
-  - pkg/runtime/serializer
-  - pkg/types
-  - pkg/util
-  - pkg/util/intstr
-  - pkg/util/rand
-  - pkg/api/v1
-  - pkg/api/validation
-  - pkg/client/metrics
-  - pkg/client/transport
-  - pkg/client/unversioned/clientcmd/api
-  - pkg/runtime/serializer/streaming
-  - pkg/util/crypto
-  - pkg/util/flowcontrol
-  - pkg/watch/versioned
-  - pkg/util/validation
-  - pkg/conversion/queryparams
-  - pkg/util/errors
-  - pkg/util/json
-  - pkg/util/validation/field
-  - pkg/apimachinery
-  - pkg/apis/apps/v1alpha1
-  - pkg/apis/authentication.k8s.io
-  - pkg/apis/authentication.k8s.io/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/batch/v1
-  - pkg/apis/componentconfig
-  - pkg/apis/componentconfig/v1alpha1
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/metrics
-  - pkg/apis/metrics/v1alpha1
-  - pkg/apis/policy/v1alpha1
-  - pkg/util/runtime
-  - plugin/pkg/client/auth/gcp
-  - third_party/forked/reflect
-  - pkg/runtime/serializer/json
-  - pkg/runtime/serializer/protobuf
-  - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/versioning
-  - pkg/util/parsers
-  - pkg/api/endpoints
-  - pkg/api/pod
-  - pkg/api/service
-  - pkg/api/unversioned/validation
-  - pkg/api/util
-  - pkg/capabilities
-  - pkg/util/yaml
-  - pkg/util/integer
-  - pkg/kubelet/qos
-  - pkg/master/ports
-  - pkg/util/framer
-  - pkg/util/hash
-  - pkg/util/net/sets
-devImports: []
+  - "1.4"
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,11 +1,12 @@
 package: github.com/deis/k8s-claimer
+ignore:
+- k8s.io/kubernetes
 import:
 - package: github.com/kelseyhightower/envconfig
 - package: github.com/pborman/uuid
 - package: cloud.google.com/go
   subpackages:
   - container
-- package: k8s.io/kubernetes
-  version: a24f03c3c99bd305ace7745b7a5749790be060e3
+- package: k8s.io/client-go/1.4
 - package: github.com/arschles/assert
 - package: github.com/codegangsta/cli

--- a/handlers/auth_middleware_test.go
+++ b/handlers/auth_middleware_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/api/container/v1"
+	container "google.golang.org/api/container/v1"
 
-	k8sapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 
 	"github.com/arschles/assert"
 	"github.com/deis/k8s-claimer/htp"
@@ -24,8 +24,8 @@ func TestWithAuthValidToken(t *testing.T) {
 	clusterLister := newFakeClusterLister(&container.ListClustersResponse{
 		Clusters: []*container.Cluster{cluster},
 	}, nil)
-	services := newFakeServiceGetterUpdater(&k8sapi.Service{
-		ObjectMeta: k8sapi.ObjectMeta{Name: "service1"},
+	services := newFakeServiceGetterUpdater(&v1.Service{
+		ObjectMeta: v1.ObjectMeta{Name: "service1"},
 	}, nil, nil, nil)
 	hdl := CreateLease(clusterLister, services, "", "", "")
 	createLeaseHandler := htp.MethodMux(map[htp.Method]http.Handler{htp.Post: hdl})

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/pborman/uuid"
-	k8sapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 func getSvcsAndClusters(
@@ -22,12 +22,12 @@ func getSvcsAndClusters(
 	gCloudProjID,
 	gCloudZone,
 	k8sServiceName string,
-) (*clusters.Map, *k8sapi.Service, error) {
+) (*clusters.Map, *v1.Service, error) {
 
 	errCh := make(chan error)
 	doneCh := make(chan struct{})
 	clusterMapCh := make(chan *clusters.Map)
-	apiServiceCh := make(chan *k8sapi.Service)
+	apiServiceCh := make(chan *v1.Service)
 	defer close(doneCh)
 	go func() {
 		svc, err := services.Get(k8sServiceName)
@@ -59,7 +59,7 @@ func getSvcsAndClusters(
 	}()
 
 	var clusterMapRet *clusters.Map
-	var apiServiceRet *k8sapi.Service
+	var apiServiceRet *v1.Service
 	for {
 		select {
 		case err := <-errCh:

--- a/handlers/create_lease_test.go
+++ b/handlers/create_lease_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pborman/uuid"
 	container "google.golang.org/api/container/v1"
 	"gopkg.in/yaml.v2"
-	k8sapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 var (
@@ -58,8 +58,8 @@ func TestCreateLeaseInvalidReq(t *testing.T) {
 func TestCreateLeaseValidResp(t *testing.T) {
 	cluster := testutil.GetClusters()[0]
 	clusterLister := newFakeClusterLister(newListClusterResp([]*container.Cluster{cluster}), nil)
-	services := newFakeServiceGetterUpdater(&k8sapi.Service{
-		ObjectMeta: k8sapi.ObjectMeta{Name: "service1"},
+	services := newFakeServiceGetterUpdater(&v1.Service{
+		ObjectMeta: v1.ObjectMeta{Name: "service1"},
 	}, nil, nil, nil)
 	hdl := CreateLease(clusterLister, services, "", "", "")
 	reqBody := `{"max_time":30}`

--- a/handlers/delete_namespaces.go
+++ b/handlers/delete_namespaces.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 
 	"github.com/deis/k8s-claimer/k8s"
-	k8sapi "k8s.io/kubernetes/pkg/api"
-	labels "k8s.io/kubernetes/pkg/labels"
+	"k8s.io/client-go/1.4/pkg/api"
 )
 
 type errListNamespaces struct {
@@ -27,7 +26,7 @@ func (e errDeleteNamespaces) Error() string {
 // deleteNamespaces deletes all namespaces listed under all labels in namespaces.List, except for
 // the namespaces in skip or skipDeleteNamespaces
 func deleteNamespaces(namespaces k8s.NamespaceListerDeleter, skip map[string]struct{}) error {
-	namespacesList, err := namespaces.List(k8sapi.ListOptions{LabelSelector: labels.Everything()})
+	namespacesList, err := namespaces.List(api.ListOptions{})
 	if err != nil {
 		return errListNamespaces{origErr: err}
 	}
@@ -37,7 +36,7 @@ func deleteNamespaces(namespaces k8s.NamespaceListerDeleter, skip map[string]str
 		_, inSkip := skip[namespace.Name]
 		_, isDefault := skipDeleteNamespaces[namespace.Name]
 		if !isDefault && !inSkip {
-			if err := namespaces.Delete(namespace.Name); err != nil {
+			if err := namespaces.Delete(namespace.Name, &api.DeleteOptions{}); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/handlers/delete_namespaces_test.go
+++ b/handlers/delete_namespaces_test.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/arschles/assert"
 	"github.com/deis/k8s-claimer/k8s"
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 func getNSListerDeleter(listedNamespaces []string) *k8s.FakeNamespaceListerDeleter {
 	ret := &k8s.FakeNamespaceListerDeleter{
 		FakeNamespaceLister: &k8s.FakeNamespaceLister{
-			NsList: &api.NamespaceList{},
+			NsList: &v1.NamespaceList{},
 		},
 		FakeNamespaceDeleter: &k8s.FakeNamespaceDeleter{},
 	}
 	for _, listedNamespace := range listedNamespaces {
-		ret.FakeNamespaceLister.NsList.Items = append(ret.FakeNamespaceLister.NsList.Items, api.Namespace{
-			ObjectMeta: api.ObjectMeta{Name: listedNamespace},
+		ret.FakeNamespaceLister.NsList.Items = append(ret.FakeNamespaceLister.NsList.Items, v1.Namespace{
+			ObjectMeta: v1.ObjectMeta{Name: listedNamespace},
 		})
 	}
 	return ret

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	kcl "k8s.io/kubernetes/pkg/client/unversioned"
+
+	"k8s.io/client-go/1.4/kubernetes"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/1.4/rest"
 )
 
 var (
@@ -42,7 +43,7 @@ func findExpiredLeases(leaseMap *leases.Map) ([]*leases.UUIDAndLease, error) {
 	return nil, errNoExpiredLeases
 }
 
-func saveAnnotations(services k8s.ServiceUpdater, svc *api.Service, leaseMap *leases.Map) error {
+func saveAnnotations(services k8s.ServiceUpdater, svc *v1.Service, leaseMap *leases.Map) error {
 	annos, err := leaseMap.ToAnnotations()
 	if err != nil {
 		return err
@@ -56,8 +57,8 @@ func saveAnnotations(services k8s.ServiceUpdater, svc *api.Service, leaseMap *le
 
 // CreateKubeClientFromConfig creates a new Kubernetes client from the given configuration.
 // returns nil and the appropriate error if the client couldn't be created for any reason
-func CreateKubeClientFromConfig(conf *k8s.KubeConfig) (*kcl.Client, error) {
-	rcConf := new(restclient.Config)
+func CreateKubeClientFromConfig(conf *k8s.KubeConfig) (*kubernetes.Clientset, error) {
+	rcConf := new(rest.Config)
 	if len(conf.Clusters) < 1 {
 		return nil, errNoClustersInConfig
 	}
@@ -77,5 +78,5 @@ func CreateKubeClientFromConfig(conf *k8s.KubeConfig) (*kcl.Client, error) {
 	rcConf.UserAgent = "k8s-claimer"
 	rcConf.Insecure = cluster.InsecureSkipTLSVerify
 
-	return kcl.New(rcConf)
+	return kubernetes.NewForConfig(rcConf)
 }

--- a/handlers/k8s_test.go
+++ b/handlers/k8s_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/deis/k8s-claimer/testutil"
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 const (
@@ -192,18 +192,18 @@ v3TGd3xXD9yQIjmugNgxNiwAZzhJs/ZJy++fPSJ1XQxbd9qPghgGoe/ff6G7
 -----END RSA PRIVATE KEY-----`
 )
 
-func newFakeServiceGetter(svc *api.Service, err error) *k8s.FakeServiceGetter {
+func newFakeServiceGetter(svc *v1.Service, err error) *k8s.FakeServiceGetter {
 	return &k8s.FakeServiceGetter{Svc: svc, Err: err}
 }
 
-func newFakeServiceUpdater(retSvc *api.Service, err error) *k8s.FakeServiceUpdater {
+func newFakeServiceUpdater(retSvc *v1.Service, err error) *k8s.FakeServiceUpdater {
 	return &k8s.FakeServiceUpdater{RetSvc: retSvc, Err: err}
 }
 
 func newFakeServiceGetterUpdater(
-	getSvc *api.Service,
+	getSvc *v1.Service,
 	getErr error,
-	updateSvc *api.Service,
+	updateSvc *v1.Service,
 	updateErr error,
 ) *k8s.FakeServiceGetterUpdater {
 	return &k8s.FakeServiceGetterUpdater{
@@ -212,7 +212,7 @@ func newFakeServiceGetterUpdater(
 	}
 }
 
-func newFakeNamespaceLister(nsList *api.NamespaceList, err error) *k8s.FakeNamespaceLister {
+func newFakeNamespaceLister(nsList *v1.NamespaceList, err error) *k8s.FakeNamespaceLister {
 	return &k8s.FakeNamespaceLister{NsList: nsList, Err: err}
 }
 
@@ -221,7 +221,7 @@ func newFakeNamespaceDeleter(err error) *k8s.FakeNamespaceDeleter {
 }
 
 func newFakeNamespaceListerDeleter(
-	listNs *api.NamespaceList,
+	listNs *v1.NamespaceList,
 	listErr error,
 	deleteErr error,
 ) *k8s.FakeNamespaceListerDeleter {

--- a/k8s/kube_config.go
+++ b/k8s/kube_config.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/client-go/1.4/pkg/runtime"
 )
 
 // KubeConfig holds the information needed to connect to remote kubernetes clusters as a given user

--- a/k8s/namespace_deleter.go
+++ b/k8s/namespace_deleter.go
@@ -1,10 +1,14 @@
 package k8s
 
+import (
+	"k8s.io/client-go/1.4/pkg/api"
+)
+
 // NamespaceDeleter is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
 // interface designed only for deleting namespaces. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type NamespaceDeleter interface {
-	Delete(name string) error
+	Delete(name string, opts *api.DeleteOptions) error
 }
 
 // FakeNamespaceDeleter is a NamespaceDeleter implementation to be used in unit tests
@@ -14,7 +18,7 @@ type FakeNamespaceDeleter struct {
 }
 
 // Delete is the NamespaceDeleter interface implementation. It just returns f.Err
-func (f *FakeNamespaceDeleter) Delete(name string) error {
+func (f *FakeNamespaceDeleter) Delete(name string, opts *api.DeleteOptions) error {
 	f.NsDeleted = append(f.NsDeleted, name)
 	return f.Err
 }

--- a/k8s/namespace_lister.go
+++ b/k8s/namespace_lister.go
@@ -1,23 +1,24 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 // NamespaceLister is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
 // interface designed only for listing namespaces. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type NamespaceLister interface {
-	List(opts api.ListOptions) (*api.NamespaceList, error)
+	List(opts api.ListOptions) (*v1.NamespaceList, error)
 }
 
 // FakeNamespaceLister is a NamespaceLister implementation to be used in unit tests
 type FakeNamespaceLister struct {
-	NsList *api.NamespaceList
+	NsList *v1.NamespaceList
 	Err    error
 }
 
 // List is the NamespaceLister interface implementation. It just returns f.NsList, f.Err
-func (f FakeNamespaceLister) List(opts api.ListOptions) (*api.NamespaceList, error) {
+func (f FakeNamespaceLister) List(opts api.ListOptions) (*v1.NamespaceList, error) {
 	return f.NsList, f.Err
 }

--- a/k8s/service_getter.go
+++ b/k8s/service_getter.go
@@ -1,23 +1,23 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 // ServiceGetter is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible
 // interface designed only for getting a service. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type ServiceGetter interface {
-	Get(name string) (*api.Service, error)
+	Get(name string) (*v1.Service, error)
 }
 
 // FakeServiceGetter is a ServiceGetter implementation to be used in unit tests
 type FakeServiceGetter struct {
-	Svc *api.Service
+	Svc *v1.Service
 	Err error
 }
 
 // Get is the ServiceGetter interface implementation. It just returns f.Svc, f.Err
-func (f FakeServiceGetter) Get(name string) (*api.Service, error) {
+func (f FakeServiceGetter) Get(name string) (*v1.Service, error) {
 	return f.Svc, f.Err
 }

--- a/k8s/service_lister.go
+++ b/k8s/service_lister.go
@@ -1,23 +1,23 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 // ServiceLister is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible
 // interface designed only for listing services. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type ServiceLister interface {
-	List(opts api.ListOptions) (*api.ServiceList, error)
+	List(opts v1.ListOptions) (*v1.ServiceList, error)
 }
 
 // FakeServiceLister is a ServiceLister implementation to be used in unit tests
 type FakeServiceLister struct {
-	SvcList *api.ServiceList
+	SvcList *v1.ServiceList
 	Err     error
 }
 
 // List is the ServiceLister interface implementation. It just returns f.SvcList, f.Err
-func (f FakeServiceLister) List(opts api.ListOptions) (*api.ServiceList, error) {
+func (f FakeServiceLister) List(opts v1.ListOptions) (*v1.ServiceList, error) {
 	return f.SvcList, f.Err
 }

--- a/k8s/service_updater.go
+++ b/k8s/service_updater.go
@@ -1,23 +1,23 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
 // ServiceUpdater is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible
 // interface designed only for updating services. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type ServiceUpdater interface {
-	Update(srv *api.Service) (*api.Service, error)
+	Update(srv *v1.Service) (*v1.Service, error)
 }
 
 // FakeServiceUpdater is a ServiceUpdater implementation to be used in unit tests
 type FakeServiceUpdater struct {
-	RetSvc *api.Service
+	RetSvc *v1.Service
 	Err    error
 }
 
 // Update is the ServiceUpdater interface implementation. It just returns f.RetSvc, f.Err
-func (f *FakeServiceUpdater) Update(srv *api.Service) (*api.Service, error) {
+func (f *FakeServiceUpdater) Update(srv *v1.Service) (*v1.Service, error) {
 	return f.RetSvc, f.Err
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,8 @@ import (
 	"github.com/deis/k8s-claimer/handlers"
 	"github.com/deis/k8s-claimer/htp"
 	"github.com/deis/k8s-claimer/k8s"
-	kcl "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/client-go/1.4/kubernetes"
+	"k8s.io/client-go/1.4/rest"
 )
 
 const (
@@ -64,7 +65,11 @@ func main() {
 		log.Fatalf("Error creating GKE client (%s)", err)
 	}
 
-	k8sClient, err := kcl.NewInCluster()
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("Error creating Kubernetes client (%s)", err)
+	}
+	k8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Fatalf("Error creating Kubernetes client (%s)", err)
 	}


### PR DESCRIPTION
This PR cuts k8s-claimer over to the official, lighter-weight k8s client.

In a previous PR, I refactored k8s-claimer to allow for the possibility of programmatic use of the k8s-claimer client... but as it turns out, using it in that manner is easier said than done, because the k8s-claimer client's dependency on the k8s client was dragging k8s' massive dependency tree along with it. No bueno.

Note that there's one small opportunity for further refactoring left on the table here-- the new k8s client has built-in fakes for just about everything. Learning to use them, however, seemed more daunting than anything I wanted to bite of as part of this PR.

cc @arschles 
