### PR TITLE
chore(*): Upgrade to latest client-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,54 +1,250 @@
-hash: db431d842e9f7ef8d705f8e29fdb85d360aa12e8f5c1004e73c7da1b096ffb91
-updated: 2016-09-27T01:47:55.033446276Z
+hash: fe3b5897656f3d5431136e2e3a199f53503ce2d8806022f1eabf036585182af9
+updated: 2016-11-07T15:06:08.313664186-05:00
 imports:
 - name: cloud.google.com/go
-  version: a706b12721e2301f4f2f9045c116f61eb95669eb
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
   subpackages:
+  - compute/metadata
   - container
+  - internal
 - name: github.com/arschles/assert
-  version: fc2da9844984ce5093111298174706e14d4c0c47
+  version: bb58b908265b5931732079df03f2818bf2167ba0
+- name: github.com/blang/semver
+  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
-  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
-- name: github.com/golang/protobuf
-  version: 87c000235d3d852c1628dc9490cd21ab36a7d69f
+  version: d86a009f5e13f83df65d0d6cee9a2e3f1445f0da
+- name: github.com/coreos/go-oidc
+  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
+- name: github.com/coreos/pkg
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
+  subpackages:
+  - health
+  - httputil
+  - timeutil
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  subpackages:
+  - digest
+  - reference
+- name: github.com/emicklei/go-restful
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  subpackages:
+  - log
+  - swagger
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+- name: github.com/gogo/protobuf
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
   - proto
+  - sortkeys
+- name: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/protobuf
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  subpackages:
+  - proto
+- name: github.com/google/gofuzz
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/jonboulle/clockwork
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/kelseyhightower/envconfig
-  version: 13674b2d056fb658a00ba3f36e78043ced07c924
+  version: 9aca109c9aec4633fced9717c4a09ecab3d33111
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
 - name: github.com/pborman/uuid
-  version: b984ec7fa9ff9e428bd0cf0abf429384dfbe3e37
+  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/pflag
+  version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
+- name: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
 - name: golang.org/x/net
-  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - lex/httplex
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
+  - google
   - internal
   - jws
   - jwt
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
 - name: google.golang.org/api
-  version: 61b3555d21f4bcfe09ddf8595c884424bc8a4ada
+  version: 9bf6e6e569ff057f75d9604a46c52928f17d2b54
   subpackages:
   - container/v1
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
 - name: google.golang.org/appengine
-  version: 8d4efd07a9358ec8c7e75b29387c31a7692db8d2
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
   subpackages:
   - internal
+  - internal/app_identity
   - internal/base
   - internal/datastore
   - internal/log
+  - internal/modules
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/client-go
-  version: 0b62e254fe853d89b1d8d3445bbdab11bcc11bc3
+  version: 49f8f1bf914a4976d303f68b0c2276452f551d34
   subpackages:
-  - "1.4"
+  - discovery
+  - kubernetes
+  - kubernetes/typed/apps/v1alpha1
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/certificates/v1alpha1
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/policy/v1alpha1
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/storage/v1beta1
+  - pkg/api
+  - pkg/api/errors
+  - pkg/api/install
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/api/validation/path
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1alpha1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1alpha1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1beta1
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/third_party/forked/golang/reflect
+  - pkg/types
+  - pkg/util
+  - pkg/util/cert
+  - pkg/util/clock
+  - pkg/util/errors
+  - pkg/util/flowcontrol
+  - pkg/util/framer
+  - pkg/util/integer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/labels
+  - pkg/util/net
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - pkg/watch/versioned
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - rest
+  - tools/clientcmd/api
+  - tools/metrics
+  - transport
+- name: k8s.io/kubernetes
+  version: dbc4121e16938d73ba66ee5f2ddc826347b5e471
+  subpackages:
+  - pkg/util/ratelimit
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,10 @@
 package: github.com/deis/k8s-claimer
-ignore:
-- k8s.io/kubernetes
 import:
 - package: github.com/kelseyhightower/envconfig
 - package: github.com/pborman/uuid
 - package: cloud.google.com/go
   subpackages:
   - container
-- package: k8s.io/client-go/1.4
+- package: k8s.io/client-go
 - package: github.com/arschles/assert
 - package: github.com/codegangsta/cli

--- a/handlers/auth_middleware_test.go
+++ b/handlers/auth_middleware_test.go
@@ -9,7 +9,7 @@ import (
 
 	container "google.golang.org/api/container/v1"
 
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/arschles/assert"
 	"github.com/deis/k8s-claimer/htp"

--- a/handlers/create_lease.go
+++ b/handlers/create_lease.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/pborman/uuid"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func getSvcsAndClusters(

--- a/handlers/create_lease_test.go
+++ b/handlers/create_lease_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pborman/uuid"
 	container "google.golang.org/api/container/v1"
 	"gopkg.in/yaml.v2"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 var (

--- a/handlers/delete_lease_test.go
+++ b/handlers/delete_lease_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/deis/k8s-claimer/testutil"
 	"github.com/pborman/uuid"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func getNSFunc(nsListerDeleter k8s.NamespaceListerDeleter, err error) func(*k8s.KubeConfig) (k8s.NamespaceListerDeleter, error) {

--- a/handlers/delete_namespaces.go
+++ b/handlers/delete_namespaces.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/deis/k8s-claimer/k8s"
-	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type errListNamespaces struct {
@@ -26,7 +26,7 @@ func (e errDeleteNamespaces) Error() string {
 // deleteNamespaces deletes all namespaces listed under all labels in namespaces.List, except for
 // the namespaces in skip or skipDeleteNamespaces
 func deleteNamespaces(namespaces k8s.NamespaceListerDeleter, skip map[string]struct{}) error {
-	namespacesList, err := namespaces.List(api.ListOptions{})
+	namespacesList, err := namespaces.List(v1.ListOptions{})
 	if err != nil {
 		return errListNamespaces{origErr: err}
 	}
@@ -36,7 +36,7 @@ func deleteNamespaces(namespaces k8s.NamespaceListerDeleter, skip map[string]str
 		_, inSkip := skip[namespace.Name]
 		_, isDefault := skipDeleteNamespaces[namespace.Name]
 		if !isDefault && !inSkip {
-			if err := namespaces.Delete(namespace.Name, &api.DeleteOptions{}); err != nil {
+			if err := namespaces.Delete(namespace.Name, &v1.DeleteOptions{}); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/handlers/delete_namespaces_test.go
+++ b/handlers/delete_namespaces_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/arschles/assert"
 	"github.com/deis/k8s-claimer/k8s"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func getNSListerDeleter(listedNamespaces []string) *k8s.FakeNamespaceListerDeleter {

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -7,9 +7,9 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/pkg/api/v1"
-	"k8s.io/client-go/1.4/rest"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
 )
 
 var (

--- a/handlers/k8s_test.go
+++ b/handlers/k8s_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/deis/k8s-claimer/k8s"
 	"github.com/deis/k8s-claimer/leases"
 	"github.com/deis/k8s-claimer/testutil"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 const (

--- a/k8s/kube_config.go
+++ b/k8s/kube_config.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/runtime"
+	"k8s.io/client-go/pkg/runtime"
 )
 
 // KubeConfig holds the information needed to connect to remote kubernetes clusters as a given user

--- a/k8s/namespace_deleter.go
+++ b/k8s/namespace_deleter.go
@@ -1,14 +1,14 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // NamespaceDeleter is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
 // interface designed only for deleting namespaces. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type NamespaceDeleter interface {
-	Delete(name string, opts *api.DeleteOptions) error
+	Delete(name string, opts *v1.DeleteOptions) error
 }
 
 // FakeNamespaceDeleter is a NamespaceDeleter implementation to be used in unit tests
@@ -18,7 +18,7 @@ type FakeNamespaceDeleter struct {
 }
 
 // Delete is the NamespaceDeleter interface implementation. It just returns f.Err
-func (f *FakeNamespaceDeleter) Delete(name string, opts *api.DeleteOptions) error {
+func (f *FakeNamespaceDeleter) Delete(name string, opts *v1.DeleteOptions) error {
 	f.NsDeleted = append(f.NsDeleted, name)
 	return f.Err
 }

--- a/k8s/namespace_lister.go
+++ b/k8s/namespace_lister.go
@@ -1,15 +1,14 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // NamespaceLister is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
 // interface designed only for listing namespaces. It should be used as a parameter to functions
 // so that they can be more easily unit tested
 type NamespaceLister interface {
-	List(opts api.ListOptions) (*v1.NamespaceList, error)
+	List(opts v1.ListOptions) (*v1.NamespaceList, error)
 }
 
 // FakeNamespaceLister is a NamespaceLister implementation to be used in unit tests
@@ -19,6 +18,6 @@ type FakeNamespaceLister struct {
 }
 
 // List is the NamespaceLister interface implementation. It just returns f.NsList, f.Err
-func (f FakeNamespaceLister) List(opts api.ListOptions) (*v1.NamespaceList, error) {
+func (f FakeNamespaceLister) List(opts v1.ListOptions) (*v1.NamespaceList, error) {
 	return f.NsList, f.Err
 }

--- a/k8s/service_getter.go
+++ b/k8s/service_getter.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // ServiceGetter is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible

--- a/k8s/service_lister.go
+++ b/k8s/service_lister.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // ServiceLister is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible

--- a/k8s/service_updater.go
+++ b/k8s/service_updater.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // ServiceUpdater is a (k8s.io/kubernetes/pkg/client/unversioned).ServiceInterface compatible

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/deis/k8s-claimer/handlers"
 	"github.com/deis/k8s-claimer/htp"
 	"github.com/deis/k8s-claimer/k8s"
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/rest"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (


### PR DESCRIPTION
client-go has recently gone through a major structural overhaul wherein, among other changes, major.minor version numbers have been removed from the fully qualified package URIs.

For instance, packages `k8s.io/client-go/1.4/pkg/api/v1` and `k8s.io/client-go/1.5/pkg/api/v1` have been eliminated in favor of `k8s.io/client-go/pkg/api/v1` and this is to be the case going forward. See notes on this [here](https://github.com/kubernetes/client-go#why-do-the-14-and-15-branch-contain-top-level-folder-named-after-the-version).

My primary motivation in opening this PR is that Steward is upgrading (or hopes to upgrade) to the latest version of client-go. Steward integration tests consume k8s-claimer programmatically, and since it's not possible to consume two different versions of the same library, k8s-claimer needs this upgrade to resolve that would-be dependency conflict.

Of course, it's an added bonus that this keeps k8s-claimer nice and current and insulates it from future busy work involving changing major.minor version numbers in paths each time this library is versioned in the future.